### PR TITLE
feat(messaging): aba 'Testes' + filtro de test personas

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -274,6 +274,62 @@ const getContactByPetOwnerIdOrPhone = async (req, res) => {
   }
 };
 
+const getAllTestContacts = async (req, res) => {
+  try {
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 15;
+    const { id, role, clinic_id } = req.user;
+
+    const responsibility = req.query.responsibility === 'true';
+    const unread = req.query.unread === 'true';
+    const tags = req?.query?.tags ? req.query.tags.split(',').filter((tag) => tag.trim()) : [];
+
+    const filters = { responsibility, unread, tags };
+
+    const result = await ChatService.getAllTestContacts({
+      user_id: id,
+      clinic_id,
+      role: role.role,
+      page,
+      limit,
+      filters,
+    });
+
+    return res.status(200).json({
+      code: 'TEST_CONTACTS_RETRIEVED',
+      data: result.contacts,
+    });
+  } catch (error) {
+    console.error('Error retrieving test contacts:', error);
+    return res.status(500).json({
+      code: 'TEST_CONTACTS_RETRIEVAL_ERROR',
+      message: error.message,
+    });
+  }
+};
+
+const getTestContactsCount = async (req, res) => {
+  try {
+    const { role, clinic_id } = req.user;
+
+    const result = await ChatService.getTestContactsCount({
+      clinic_id,
+      role: role.role,
+    });
+
+    return res.status(200).json({
+      code: 'TEST_CONTACTS_COUNT_RETRIEVED',
+      data: { count: result.count },
+    });
+  } catch (error) {
+    console.error('Error retrieving test contacts count:', error);
+    return res.status(500).json({
+      code: 'TEST_CONTACTS_COUNT_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   getAllContactsWithMessages,
   getAllContactsBeingAttended,
@@ -281,4 +337,6 @@ export default {
   getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerId,
   getContactByPetOwnerIdOrPhone,
+  getAllTestContacts,
+  getTestContactsCount,
 };

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -19,6 +19,14 @@ import {
   TemplateVariableType,
 } from '../models/index.js';
 
+// Telefones de test personas (scripts/test-onboarding-personas.ts): 55000000000XX
+const TEST_PHONE_REGEX = '^5500000000[0-9]{3}$';
+const buildTestPhoneFilter = (testFilter = 'exclude') => {
+  if (testFilter === 'only') return `AND po.cell_phone ~ '${TEST_PHONE_REGEX}'`;
+  if (testFilter === 'none') return '';
+  return `AND (po.cell_phone IS NULL OR po.cell_phone !~ '${TEST_PHONE_REGEX}')`;
+};
+
 const getAllContactsWithMessages = async ({
   clinic_id,
   role,
@@ -26,6 +34,7 @@ const getAllContactsWithMessages = async ({
   limit = 15,
   user_id,
   filters = {},
+  testFilter = 'exclude',
 }) => {
   try {
     const offset = (page - 1) * limit;
@@ -33,6 +42,8 @@ const getAllContactsWithMessages = async ({
 
     const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
     const chatHistoryWhere = shouldFilterLatta ? { path: { [Op.ne]: 'latta' } } : {};
+
+    const testPhoneFilter = buildTestPhoneFilter(testFilter);
 
     // Filtro base: contatos da clínica QUE TÊM pelo menos uma chat_history.
     // O EXISTS substitui o antigo `required: true` no include de chatHistory,
@@ -46,6 +57,7 @@ const getAllContactsWithMessages = async ({
           INNER JOIN pet_owners po ON c.pet_owner_id = po.id
           INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
           WHERE poc.clinic_id = '${clinic_id}'
+          ${testPhoneFilter}
           AND EXISTS (
             SELECT 1 FROM chat_history ch
             WHERE ch.contact_id = c.id
@@ -65,13 +77,14 @@ const getAllContactsWithMessages = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT DISTINCT c.id 
+            SELECT DISTINCT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
             INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
             INNER JOIN pet_owner_tag_assignments pota ON po.id = pota.pet_owner_id
             WHERE pota.tag_id IN (${escapedTags})
             AND poc.clinic_id = '${clinic_id}'
+            ${testPhoneFilter}
           )`),
         },
       });
@@ -82,11 +95,12 @@ const getAllContactsWithMessages = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT c.id 
+            SELECT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
             INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
             WHERE poc.clinic_id = '${clinic_id}'
+            ${testPhoneFilter}
             AND EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
@@ -109,11 +123,12 @@ const getAllContactsWithMessages = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT c.id 
+            SELECT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
             INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
             WHERE poc.clinic_id = '${clinic_id}'
+            ${testPhoneFilter}
             AND EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
@@ -342,6 +357,7 @@ const getAllContactsBeingAttended = async ({
   limit = 15,
   user_id,
   filters = {},
+  testFilter = 'exclude',
 }) => {
   try {
     const offset = (page - 1) * limit;
@@ -349,6 +365,7 @@ const getAllContactsBeingAttended = async ({
 
     const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
     const chatHistoryWhere = shouldFilterLatta ? { path: { [Op.ne]: 'latta' } } : {};
+    const testPhoneFilter = buildTestPhoneFilter(testFilter);
 
     // Filtro base: contatos em atendimento na clínica QUE TÊM chat_history.
     // O EXISTS substitui o antigo `required: true` no include de chatHistory,
@@ -363,6 +380,7 @@ const getAllContactsBeingAttended = async ({
           INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
           WHERE poc.clinic_id = '${clinic_id}'
           AND c.is_being_attended = true
+          ${testPhoneFilter}
           AND EXISTS (
             SELECT 1 FROM chat_history ch
             WHERE ch.contact_id = c.id
@@ -382,7 +400,7 @@ const getAllContactsBeingAttended = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT DISTINCT c.id 
+            SELECT DISTINCT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
             INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
@@ -390,6 +408,7 @@ const getAllContactsBeingAttended = async ({
             WHERE pota.tag_id IN (${escapedTags})
             AND poc.clinic_id = '${clinic_id}'
             AND c.is_being_attended = true
+            ${testPhoneFilter}
           )`),
         },
       });
@@ -400,12 +419,13 @@ const getAllContactsBeingAttended = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT c.id 
+            SELECT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
             INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
             WHERE poc.clinic_id = '${clinic_id}'
             AND c.is_being_attended = true
+            ${testPhoneFilter}
             AND EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
@@ -428,12 +448,13 @@ const getAllContactsBeingAttended = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT c.id 
+            SELECT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
             INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
             WHERE poc.clinic_id = '${clinic_id}'
             AND c.is_being_attended = true
+            ${testPhoneFilter}
             AND EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
@@ -1702,6 +1723,37 @@ const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 20 }) => 
   }
 };
 
+const getTestContactsCount = async ({ clinic_id, role }) => {
+  try {
+    const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
+
+    const [result] = await Contact.sequelize.query(
+      `
+      SELECT COUNT(DISTINCT c.id)::int AS count
+      FROM contacts c
+      INNER JOIN pet_owners po ON c.pet_owner_id = po.id
+      INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
+      WHERE poc.clinic_id = :clinic_id
+      AND po.cell_phone ~ :test_phone_regex
+      AND EXISTS (
+        SELECT 1 FROM chat_history ch
+        WHERE ch.contact_id = c.id
+        ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
+      )
+      `,
+      {
+        replacements: { clinic_id, test_phone_regex: TEST_PHONE_REGEX },
+        type: Sequelize.QueryTypes.SELECT,
+      },
+    );
+
+    return { count: result?.count || 0 };
+  } catch (error) {
+    console.error('❌ ERRO getTestContactsCount:', error.message);
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 export default {
   getAllContactsWithMessages,
   getAllContactsBeingAttended,
@@ -1710,4 +1762,5 @@ export default {
   getContactByPetOwnerId,
   getContactByPetOwnerIdOrPhone,
   getAllContactsMessagesWithNoFilters,
+  getTestContactsCount,
 };

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -19,6 +19,20 @@ router.get(
 );
 
 router.get(
+  '/messages/getAllTestContacts',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getAllTestContacts,
+);
+
+router.get(
+  '/messages/getTestContactsCount',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getTestContactsCount,
+);
+
+router.get(
   '/messages/searchContacts',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'attendant']),

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -57,6 +57,7 @@ const getAllContactsWithMessages = async ({
   limit = 15,
   user_id,
   filters = {},
+  testFilter = 'exclude',
 }) => {
   try {
     const result = await ChatRepository.getAllContactsWithMessages({
@@ -66,6 +67,7 @@ const getAllContactsWithMessages = async ({
       limit,
       user_id,
       filters, // Repassa os filtros para o repository
+      testFilter,
     });
     const contacts = result.contacts;
 
@@ -77,6 +79,33 @@ const getAllContactsWithMessages = async ({
       totalItems: result.totalItems,
       totalPages: Math.ceil(result.totalItems / limit),
     };
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
+const getAllTestContacts = async ({
+  clinic_id,
+  role,
+  page = 1,
+  limit = 15,
+  user_id,
+  filters = {},
+}) => {
+  return getAllContactsWithMessages({
+    clinic_id,
+    role,
+    page,
+    limit,
+    user_id,
+    filters,
+    testFilter: 'only',
+  });
+};
+
+const getTestContactsCount = async ({ clinic_id, role }) => {
+  try {
+    return await ChatRepository.getTestContactsCount({ clinic_id, role });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
@@ -231,4 +260,6 @@ export default {
   getContactByPetOwnerId,
   getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerIdOrPhone,
+  getAllTestContacts,
+  getTestContactsCount,
 };


### PR DESCRIPTION
## Contexto

Na tela de mensageria da plataforma, contatos de personas de teste (telefones `55000000000XX` criados por [scripts/test-onboarding-personas.ts](https://github.com/Matheus3FY/Latta/blob/main/scripts/test-onboarding-personas.ts)) estavam se misturando com conversas reais em Geral/Suporte. Parte de um conjunto de 3 PRs coordenados (backend + frontend + supabase EF).

## Mudanças

- **`repositories/chat-history.repository.js`**: novo parâmetro `testFilter` (`'exclude' | 'only' | 'none'`, default `'exclude'`) em `getAllContactsWithMessages` e `getAllContactsBeingAttended`. Helper `buildTestPhoneFilter` injeta o regex `^5500000000[0-9]{3}$` no SQL literal de todas as condições (base + tags + responsibility + unread). Novo método `getTestContactsCount` enxuto que retorna só `COUNT`.
- **`services/chat-history.service.js`**: novo `getAllTestContacts` (thin wrapper chamando `getAllContactsWithMessages` com `testFilter='only'`) + `getTestContactsCount`.
- **`controllers/chat-history.controller.js`**: 2 novos handlers.
- **`routes/private/chat-history.routes.js`**: 2 novas rotas `GET /chat-history/messages/getAllTestContacts` e `GET /chat-history/messages/getTestContactsCount`.

## Comportamento

- Rotas existentes (`getAllContactsWithMessages`, `getAllContactsBeingAttended`) passam a EXCLUIR automaticamente qualquer contato com `pet_owners.cell_phone ~ '^5500000000[0-9]{3}$'`.
- Nova rota `getAllTestContacts` retorna APENAS esses contatos.
- Nova rota `getTestContactsCount` alimenta o badge dinâmico do frontend — se `count === 0`, a aba 'Testes' não aparece.

## Test plan

- [ ] Backend sobe sem erro (`npm run dev`)
- [ ] `GET /chat-history/messages/getAllContactsWithMessages` não retorna telefones `55000000000XX`
- [ ] `GET /chat-history/messages/getAllContactsBeingAttended` idem
- [ ] `GET /chat-history/messages/getAllTestContacts` retorna EXCLUSIVAMENTE `55000000000XX`
- [ ] `GET /chat-history/messages/getTestContactsCount` retorna o número correto
- [ ] Filtros existentes (tags, responsibility, unread) continuam funcionando em Geral/Suporte

## Follow-up (não neste PR)

- Adicionar `order: [['created_at', 'ASC']]` no include de `Pet` pra garantir que o mapping frontend "Pet nº N → nome" é estável (hoje depende de ordem indefinida do Sequelize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)