### PR TITLE
fix(messaging): excluir test personas na rota sem filtros

### DIFF
--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -1461,8 +1461,21 @@ const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 20 }) => 
     const offset = (page - 1) * limit;
     const { Op } = Sequelize;
 
+    // Exclui test personas (55000000000XX) mesmo no modo "sem filtros" —
+    // elas têm sua própria aba "Testes" no frontend e poluem a visualização
+    // quando misturadas aos contatos reais.
+    const testPersonaExcludeWhere = {
+      id: {
+        [Op.notIn]: Sequelize.literal(`(
+          SELECT c.id FROM contacts c
+          INNER JOIN pet_owners po ON c.pet_owner_id = po.id
+          WHERE po.cell_phone ~ '${TEST_PHONE_REGEX}'
+        )`),
+      },
+    };
 
     const { count: totalItems, rows: contacts } = await Contact.findAndCountAll({
+      where: testPersonaExcludeWhere,
       limit,
       offset,
       distinct: true,


### PR DESCRIPTION
## Contexto

Follow-up do PR #4. Usuário (Lucas) reportou que mesmo após o deploy, contatos 55000000000XX continuavam em Geral quando logado como debuger@latta.app.

## Causa

O debug user usa a rota /chat-history/messages/getAllContactsMessagesWithNoFilters, que por design retorna todos os contatos sem filtro de clinic_id/role. No PR anterior deixei ela intocada. Mas sem filtros era muito literal — estava trazendo test personas junto.

## Fix

Adiciona where clause com Op.notIn + subquery literal usando TEST_PHONE_REGEX (constante já definida no topo pelo PR anterior). Agora a aba Testes é o único lugar onde test personas aparecem, mesmo no modo debugger.

## Test plan

- [ ] Logar como debuger@latta.app → Geral NAO lista 55000000000XX
- [ ] Aba Testes continua listando so 55000000000XX
- [ ] Usuario normal: regressao OK (nenhuma mudanca nas rotas que ele usa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)