### PR TITLE
fix(messaging): aba Testes lista vazia — usar LEFT JOIN em getAllContactsWithMessages

### DIFF
--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -58,9 +58,25 @@ const getAllContactsWithMessages = async ({
     // O EXISTS substitui o antigo `required: true` no include de chatHistory,
     // que não funciona junto com `separate: true` (necessário para o limit
     // por contato funcionar corretamente).
-    let whereConditions = {
-      id: {
-        [Op.in]: Sequelize.literal(`(
+    //
+    // Quando testFilter === 'only' (aba Testes), usamos LEFT JOIN + OR IS NULL
+    // para alinhar com getTestContactsCount (linha ~1770): test personas criadas
+    // pelo script de testes NÃO têm row em pet_owner_clinics, então INNER JOIN
+    // as excluiria e a aba Testes ficaria vazia mesmo com count > 0. Bug real
+    // reportado em 2026-04-14 (count=14 mas lista []).
+    const baseSubquery = testFilter === 'only'
+      ? `(
+          SELECT DISTINCT c.id
+          FROM contacts c
+          LEFT JOIN pet_owners po ON c.pet_owner_id = po.id
+          LEFT JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
+          WHERE (poc.clinic_id = '${clinic_id}' OR poc.clinic_id IS NULL)
+          AND EXISTS (
+            SELECT 1 FROM chat_history ch
+            WHERE ch.contact_id = c.id
+          )
+        )`
+      : `(
           SELECT DISTINCT c.id
           FROM contacts c
           INNER JOIN pet_owners po ON c.pet_owner_id = po.id
@@ -71,7 +87,11 @@ const getAllContactsWithMessages = async ({
             WHERE ch.contact_id = c.id
             ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
           )
-        )`),
+        )`;
+
+    let whereConditions = {
+      id: {
+        [Op.in]: Sequelize.literal(baseSubquery),
       },
     };
 


### PR DESCRIPTION
## Bug

A aba \"Testes\" da mensageria exibia o badge com count (14 test personas) mas a lista de chats ficava vazia. Inconsistência entre duas queries do mesmo arquivo:

- [\`getTestContactsCount\`](src/api/repositories/chat-history.repository.js#L1762) (badge) usa \`LEFT JOIN pet_owner_clinics poc\` + \`WHERE (poc.clinic_id = X OR poc.clinic_id IS NULL)\`.
- [\`getAllContactsWithMessages\`](src/api/repositories/chat-history.repository.js#L61) (listagem, incluindo \`testFilter='only'\`) usa \`INNER JOIN pet_owner_clinics poc\` + \`WHERE poc.clinic_id = X\`, sem fallback para NULL.

Test personas criadas por [\`scripts/test-onboarding-personas.ts\`](../Matheus3FY/Latta/blob/main/scripts/test-onboarding-personas.ts) **não** criam row em \`pet_owner_clinics\` quando \`TEST_CLINIC_ID\` não está setado. Resultado: o count encontra 14 (LEFT JOIN), a listagem encontra 0 (INNER JOIN exclui).

## Fix

Quando \`testFilter === 'only'\`, usar LEFT JOIN + OR IS NULL para alinhar com o \`getTestContactsCount\`. Comportamento normal (sem test filter) fica intocado — não afeta abas Geral/Suporte.

## Test plan

- [x] Curl do endpoint com JWT do debuger:
  \`\`\`bash
  curl -H \"Authorization: Bearer \$TOKEN\" \\
    \"https://api.latta.app.br/api/chat-history/messages/getAllTestContacts?page=1&limit=15\"
  \`\`\`
  Antes: \`{ code: 'TEST_CONTACTS_RETRIEVED', data: [] }\`
  Depois (esperado): \`{ code: 'TEST_CONTACTS_RETRIEVED', data: [<14 contacts>] }\`
- [ ] UI: abrir https://latta.app.br/chats, clicar na aba **Testes**, confirmar que as 14 test personas aparecem na lista
- [ ] Regressão: abas **Geral** e **Suporte** continuam funcionando normalmente (query sem \`testFilter='only'\` não foi alterada)