### PR TITLE
fix(messaging): filtrar test personas também por cellphone range

### DIFF
--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -20,15 +20,23 @@ import {
 } from '../models/index.js';
 
 // Test personas (scripts/test-onboarding-personas.ts): phones 5500000000XXX.
-// Source of truth no banco: chat_history.path LIKE 'test-persona|%'.
-// A EF chat-history-logger prefixa o path automaticamente ao gravar chats
-// desses phones (ver supabase/functions/chat-history-logger/index.ts:73).
-// Usamos ESSA fonte de verdade pra filtrar ao invés de regex no phone —
-// mesmo marcador usado pelo skill /delete-test-personas.
+// DUAS fontes de verdade (UNION) pra garantir que nenhum test persona vaza
+// pra aba "Geral":
+//   1) chat_history.path LIKE 'test-persona|%' — marker gravado pela EF
+//      chat-history-logger (supabase/functions/chat-history-logger/index.ts:73)
+//      ao processar phones no range.
+//   2) contacts.cellphone ~ '^5500000000[0-9]{3}$' — range oficial das test
+//      personas documentado em .claude/rules/general-rules.md. Cobre contacts
+//      criados direto via script (sem passar pela EF) ou cujo chat_history
+//      foi gravado antes do marker existir. Auditoria SQL 2026-04-24 detectou
+//      9 test personas vazando por depender só do marker.
 // Detalhes: docs/knowledge/test-personas.md
 const TEST_CONTACT_IDS_SUBQUERY = `(
   SELECT DISTINCT ch.contact_id FROM chat_history ch
   WHERE ch.path LIKE 'test-persona|%' AND ch.contact_id IS NOT NULL
+  UNION
+  SELECT c.id FROM contacts c
+  WHERE c.cellphone ~ '^5500000000[0-9]{3}$'
 )`;
 
 const buildTestChatFilter = (testFilter = 'exclude') => {


### PR DESCRIPTION
## Summary
- UNION no `TEST_CONTACT_IDS_SUBQUERY` para cobrir test personas criadas via script (sem passar pela EF chat-history-logger)
- 9 contatos vazando na aba "Geral" ("Tutor Novo", "Tutor Indeciso", "Tutor Multi", "Tutor Recusa", "Persona Access Err", "Persona Access Lucas", etc.)
- Fix de 3 linhas — apenas `chat-history.repository.js`. Sem migration.

## Root cause
Antes, o filtro usava só `chat_history.path LIKE 'test-persona|%'` (marker EF). Contatos criados direto via `scripts/test-onboarding-personas.ts` nunca geraram chat_history com esse marker e passavam pelo `Op.notIn`, vazando pra aba Geral.

Auditoria SQL:
- Total contacts em range `5500000000%`: 75
- Contacts pegos pelo filtro antigo: 66
- Delta: 9 contatos vazando

## Test plan
- [x] Pré-validação SQL: \`new_filter_count=75, old_filter_count=66\` (delta +9)
- [ ] Deploy EC2
- [ ] Login como debug user → aba "Geral" não mostra test personas
- [ ] Aba "Testes" counter subiu de 66 pra 75
- [ ] Contatos reais (Matheus Araújo, Leonardo Bossi) continuam visíveis na Geral

## Fora de escopo
- Bug de duplicação (Matheus Araújo 2x — falta de normalização BR + UNIQUE em cellphone) — PR separado
- Normalização de phone nos pontos de inserção de \`contacts\` — PR separado

🤖 Generated with [Claude Code](https://claude.com/claude-code)