### PR TITLE
feat(chat-history): endpoint getContactByContactId + socket tuning

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -168,6 +168,57 @@ const getContactByPetOwnerId = async (req, res) => {
   }
 };
 
+const getContactByContactId = async (req, res) => {
+  try {
+    const { contact_id } = req.params;
+    const { role } = req.user;
+    const { page = 1, limit = 20 } = req.query;
+
+    if (!contact_id) {
+      return res.status(400).json({
+        code: 'MISSING_CONTACT_ID',
+        message: 'contact_id is required',
+      });
+    }
+
+    const pageNum = parseInt(page);
+    const limitNum = parseInt(limit);
+
+    if (pageNum < 1 || limitNum < 1 || limitNum > 100) {
+      return res.status(400).json({
+        code: 'INVALID_PAGINATION_PARAMS',
+        message: 'Invalid pagination parameters',
+      });
+    }
+
+    const result = await ChatService.getContactByContactId({
+      contact_id,
+      role: role.role,
+      page: pageNum,
+      limit: limitNum,
+    });
+
+    if (!result || !result.contact) {
+      return res.status(404).json({
+        code: 'CONTACT_NOT_FOUND',
+        message: 'No contact found for this id',
+      });
+    }
+
+    return res.status(200).json({
+      code: 'CONTACT_RETRIEVED',
+      data: result.contact,
+      pagination: result.pagination,
+    });
+  } catch (error) {
+    console.error('Error retrieving contact by contact id:', error);
+    return res.status(500).json({
+      code: 'CONTACT_RETRIEVAL_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getAllContactsMessagesWithNoFilters = async (req, res) => {
   try {
     const { role } = req.user;
@@ -336,6 +387,7 @@ export default {
   searchContacts,
   getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerId,
+  getContactByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getTestContactsCount,

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -1510,6 +1510,181 @@ const getContactByPetOwnerId = async ({ pet_owner_id, role, page = 1, limit = 20
   }
 };
 
+const getContactByContactId = async ({ contact_id, role, page = 1, limit = 20 }) => {
+  try {
+    const { Op } = Sequelize;
+    const offset = (page - 1) * limit;
+
+    const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
+    const chatHistoryWhere = shouldFilterLatta ? { path: { [Op.ne]: 'latta' } } : {};
+
+    const contact = await Contact.findOne({
+      where: { id: contact_id },
+      order: [
+        [{ model: ChatHistory, as: 'chatHistory' }, 'timestamp', 'DESC'],
+      ],
+      include: [
+        {
+          model: ChatHistory,
+          as: 'chatHistory',
+          where: {
+            ...chatHistoryWhere,
+            id: {
+              [Op.in]: Sequelize.literal(`(
+                SELECT ch.id
+                FROM chat_history ch
+                WHERE ch.contact_id = "Contact".id
+                ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
+                ORDER BY ch.timestamp DESC
+                LIMIT ${limit} OFFSET ${offset}
+              )`),
+            },
+          },
+          attributes: [
+            'id',
+            [Sequelize.fn('LEFT', Sequelize.col('chatHistory.message'), 8000), 'message'],
+            'sent_by',
+            'sent_to',
+            'role',
+            'timestamp',
+            'window_timestamp',
+            'journey',
+            'message_type',
+            'date',
+            'message_id',
+            'midia_url',
+            'midia_name',
+            'reply',
+            'path',
+            'user_id',
+            'is_answered',
+            'template_id',
+            'n8n_execution_id',
+            'n8n_workflow_id',
+          ],
+          required: false,
+          order: [['timestamp', 'DESC']],
+          include: [
+            {
+              model: ChatHistoryContacts,
+              as: 'chatHistoryContacts',
+              attributes: [
+                'id',
+                'contact_name',
+                'cellphone',
+                'contact_phone',
+                'message_id',
+                'created_at',
+                'updated_at',
+              ],
+            },
+            {
+              model: Template,
+              as: 'template',
+              order: [['template_label', 'ASC']],
+              attributes: [
+                'id',
+                'template_name',
+                'template_label',
+                'template_category',
+                'template_status',
+              ],
+              include: [
+                {
+                  model: TemplateVariable,
+                  as: 'variables',
+                  attributes: [
+                    'id',
+                    'template_id',
+                    'template_component_id',
+                    'template_component_type_id',
+                    'template_varible_type_id',
+                    'variable_position',
+                  ],
+                  include: [
+                    {
+                      model: TemplateVariableType,
+                      as: 'templateVariableType',
+                      attributes: ['id', 'type', 'description', 'n8n_formula'],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          model: PetOwner,
+          as: 'petOwner',
+          attributes: [
+            'id',
+            'name',
+            'email',
+            'cell_phone',
+            'cpf',
+            'date_of_birth',
+            'is_active',
+            'created_at',
+          ],
+          include: [
+            {
+              model: Pet,
+              as: 'pets',
+              attributes: ['id', 'name', 'date_of_birthday', 'photo', 'photo_thumb', 'pet_subscription_id'],
+              through: { attributes: [] },
+              where: { is_active: true },
+              required: false,
+              include: [
+                { model: PetType, as: 'type', attributes: ['id', 'name', 'label'] },
+                { model: PetBreed, as: 'breed', attributes: ['id', 'name', 'label'] },
+                { model: PetGender, as: 'gender', attributes: ['id', 'name', 'label'] },
+                { model: PetSize, as: 'size', attributes: ['id', 'name', 'label'] },
+                { model: PetFurLength, as: 'furLength', attributes: ['id', 'name', 'label'] },
+                { model: PetSubscription, as: 'subscription', attributes: ['id', 'name'] },
+              ],
+            },
+            {
+              model: PetOwnerTag,
+              as: 'tags',
+              attributes: ['id', 'name', 'label', 'color', 'is_active'],
+              through: { attributes: ['assigned_at', 'user_id'] },
+              order: [['name', 'ASC']],
+              where: { is_active: true },
+              required: false,
+            },
+          ],
+          required: false,
+        },
+      ],
+    });
+
+    let totalMessages = 0;
+    if (contact) {
+      totalMessages = await ChatHistory.count({
+        where: {
+          contact_id: contact.id,
+          ...chatHistoryWhere,
+        },
+      });
+    }
+
+    return {
+      contact,
+      pagination: {
+        currentPage: page,
+        limit,
+        totalMessages,
+        hasMore: totalMessages > page * limit,
+        totalPages: Math.ceil(totalMessages / limit),
+      },
+    };
+  } catch (error) {
+    console.error('❌ ERRO NA FUNÇÃO getContactByContactId:', error.message);
+    console.error('❌ STACK:', error.stack);
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 20 }) => {
   try {
     const offset = (page - 1) * limit;
@@ -1828,6 +2003,7 @@ export default {
   searchContacts,
   getReplyMessageById,
   getContactByPetOwnerId,
+  getContactByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllContactsMessagesWithNoFilters,
   getTestContactsCount,

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -47,6 +47,13 @@ router.get(
 );
 
 router.get(
+  '/messages/getContactByContactId/:contact_id',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getContactByContactId,
+);
+
+router.get(
   '/messages/getContactByPetOwnerIdOrPhone',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'attendant']),

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -194,6 +194,28 @@ const getContactByPetOwnerId = async ({ pet_owner_id, role, page = 1, limit = 20
   }
 };
 
+const getContactByContactId = async ({ contact_id, role, page = 1, limit = 20 }) => {
+  try {
+    const result = await ChatRepository.getContactByContactId({
+      contact_id,
+      role,
+      page,
+      limit,
+    });
+
+    if (!result.contact) {
+      return null;
+    }
+
+    await attachReplyMessages([result.contact]);
+    await signMessagesMediaUrls([result.contact]);
+
+    return result;
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
 const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 15 }) => {
   try {
     const result = await ChatRepository.getAllContactsMessagesWithNoFilters({
@@ -258,6 +280,7 @@ export default {
   getAllContactsBeingAttended,
   searchContacts,
   getContactByPetOwnerId,
+  getContactByContactId,
   getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,

--- a/src/config/socket.js
+++ b/src/config/socket.js
@@ -13,8 +13,11 @@ function initializeSocket(httpServer) {
     },
     transports: ['websocket', 'polling'],
     allowEIO3: true,
-    pingTimeout: 60000,
-    pingInterval: 25000,
+    // Ping rápido (10s) + timeout curto (20s) pra detectar sockets mortos em
+    // ~20s em vez de 60s+. Reduz janela em que o admin vê "conectado" mas não
+    // recebe `new_message` porque a WS caiu silenciosa.
+    pingTimeout: 20000,
+    pingInterval: 10000,
     maxHttpBufferSize: 1e6,
     connectTimeout: 45000,
     forceNew: false,


### PR DESCRIPTION
## Summary
- Novo endpoint `GET /chat-history/messages/getContactByContactId/:contact_id` — busca histórico por `contact_id` (útil quando contato vem via socket sem `pet_owner_id`)
- Espelha pattern do `getContactByPetOwnerId`: inclui chatHistory, petOwner opcional, pets, tags, template + paginação
- Socket tuning: `pingInterval 10s` + `pingTimeout 20s` (antes 25s/60s) — detecta sockets mortos em ~20s

## Contexto
Onboarding inicial grava mensagens em chat_history via EF \`chat-history-logger\` (Fase 3 concluída). O contato é criado pela EF ao resolver o phone, mas \`pet_owner_id\` pode ser null até o Activate Code. Frontend recebe mensagens via socket e cria \`Contact\` local, mas ao abrir só via 1 mensagem (a que chegou pelo WS). Agora busca histórico completo pelo \`contact_id\`.

## Test plan
- [ ] Deploy na EC2
- [ ] Login como admin na mensageria
- [ ] Novo persona de teste manda \`oi\` no WhatsApp
- [ ] Admin vê contato aparecer em tempo real
- [ ] Admin clica no contato → deve ver **todas** as mensagens iniciais (oi, saudação Latta, carrossel), não só a última
- [ ] Socket pinga a cada 10s, desconexões detectadas em <30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)