### PR TITLE
feat(messaging): endpoint markAsAnswered (substitui webhook N8n)

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -381,6 +381,34 @@ const getTestContactsCount = async (req, res) => {
   }
 };
 
+// POST /chat-history/messages/markAsAnswered { pet_owner_id }
+// Migrado do webhook N8n is_answered (workflow Lattinha - Webhooks Front).
+const markAsAnswered = async (req, res) => {
+  try {
+    const { pet_owner_id } = req.body || {};
+
+    if (!pet_owner_id) {
+      return res.status(400).json({
+        code: 'PET_OWNER_ID_REQUIRED',
+        message: 'pet_owner_id é obrigatório',
+      });
+    }
+
+    const result = await ChatService.markAsAnswered({ pet_owner_id });
+
+    return res.status(200).json({
+      code: 'MESSAGES_MARKED_AS_ANSWERED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Error marking messages as answered:', error);
+    return res.status(500).json({
+      code: 'MARK_AS_ANSWERED_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   getAllContactsWithMessages,
   getAllContactsBeingAttended,
@@ -391,4 +419,5 @@ export default {
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getTestContactsCount,
+  markAsAnswered,
 };

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -81,4 +81,13 @@ router.get(
   ChatController.getAllContactsMessagesWithNoFilters,
 );
 
+// Marca mensagens não-respondidas de um pet_owner como answered (substitui
+// o webhook N8n `is_answered` em Lattinha - Webhooks Front).
+router.post(
+  '/messages/markAsAnswered',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.markAsAnswered,
+);
+
 export default router;

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -2,6 +2,7 @@ import ChatRepository from '../repositories/chat-history.repository.js';
 import S3ClientUtil from '../../utils/s3.js';
 import { normalizeQuery } from '../../utils/normalizeQuery.js';
 import { isValidUUID } from '../../utils/validate.js';
+import { ChatHistory, Contact } from '../models/index.js';
 
 const signMessagesMediaUrls = async (contacts) => {
   for (const contact of contacts) {
@@ -275,6 +276,41 @@ const getContactByPetOwnerIdOrPhone = async ({
   }
 };
 
+// Marca todas mensagens não-respondidas de um pet_owner como is_answered=true.
+// Substitui o webhook N8n `is_answered` (workflow Lattinha - Webhooks Front).
+//
+// Chamado pelo frontend quando o atendente abre uma conversa com mensagens
+// pendentes — o badge de unread some na próxima atualização do contact.
+//
+// Lookup do cellphone via Contact.pet_owner_id; UPDATE chat_history em
+// batch onde cell_phone match e is_answered=false. Retorna count atualizado.
+const markAsAnswered = async ({ pet_owner_id }) => {
+  if (!pet_owner_id || !isValidUUID(pet_owner_id)) {
+    throw new Error('pet_owner_id inválido');
+  }
+
+  const contact = await Contact.findOne({
+    where: { pet_owner_id },
+    attributes: ['cellphone'],
+  });
+
+  if (!contact?.cellphone) {
+    return { updated: 0, cellphone: null };
+  }
+
+  const [updated] = await ChatHistory.update(
+    { is_answered: true },
+    {
+      where: {
+        cell_phone: contact.cellphone,
+        is_answered: false,
+      },
+    },
+  );
+
+  return { updated, cellphone: contact.cellphone };
+};
+
 export default {
   getAllContactsWithMessages,
   getAllContactsBeingAttended,
@@ -285,4 +321,5 @@ export default {
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getTestContactsCount,
+  markAsAnswered,
 };


### PR DESCRIPTION
## Summary
Migra a lógica de "marcar conversa como lida" do webhook N8n \`is_answered\` (workflow \`Lattinha - Webhooks Front\` ID \`UHSf3aB5rMiqYorD\`) pra um endpoint Express autenticado.

## Endpoint
\`POST /api/chat-history/messages/markAsAnswered\`
Body: \`{ pet_owner_id: UUID }\`
Auth: verifyToken + checkRole admin/superAdmin/attendant

## Mudanças
- \`chat-history.service.js\` — novo método \`markAsAnswered({pet_owner_id})\`: lookup Contact.cellphone via pet_owner_id, batch UPDATE \`chat_history.is_answered=true WHERE cell_phone=<x> AND is_answered=false\`
- \`chat-history.controller.js\` — handler com validação de pet_owner_id obrigatório
- \`chat-history.routes.js\` — POST registrado

## Test plan
- [ ] Deploy EC2
- [ ] Smoke test: \`curl -X POST .../chat-history/messages/markAsAnswered -H "Authorization: Bearer <token>" -d '{"pet_owner_id":"..."}'\`
- [ ] Frontend (PR separado) atualizado pra chamar este endpoint em vez do webhook N8n

🤖 Generated with [Claude Code](https://claude.com/claude-code)