### PR TITLE
fix(messaging): markAsAnswered aceita cell_phone

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -381,20 +381,22 @@ const getTestContactsCount = async (req, res) => {
   }
 };
 
-// POST /chat-history/messages/markAsAnswered { pet_owner_id }
+// POST /chat-history/messages/markAsAnswered { cell_phone, pet_owner_id }
 // Migrado do webhook N8n is_answered (workflow Lattinha - Webhooks Front).
+// Aceita cell_phone OU pet_owner_id — pelo menos um deve vir. cell_phone
+// é preferido pq cobre contacts sem pet_owner vinculado (leads novos).
 const markAsAnswered = async (req, res) => {
   try {
-    const { pet_owner_id } = req.body || {};
+    const { pet_owner_id, cell_phone } = req.body || {};
 
-    if (!pet_owner_id) {
+    if (!pet_owner_id && !cell_phone) {
       return res.status(400).json({
-        code: 'PET_OWNER_ID_REQUIRED',
-        message: 'pet_owner_id é obrigatório',
+        code: 'IDENTIFIER_REQUIRED',
+        message: 'cell_phone ou pet_owner_id é obrigatório',
       });
     }
 
-    const result = await ChatService.markAsAnswered({ pet_owner_id });
+    const result = await ChatService.markAsAnswered({ pet_owner_id, cell_phone });
 
     return res.status(200).json({
       code: 'MESSAGES_MARKED_AS_ANSWERED',

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -276,25 +276,28 @@ const getContactByPetOwnerIdOrPhone = async ({
   }
 };
 
-// Marca todas mensagens não-respondidas de um pet_owner como is_answered=true.
+// Marca todas mensagens não-respondidas de um contact como is_answered=true.
 // Substitui o webhook N8n `is_answered` (workflow Lattinha - Webhooks Front).
 //
-// Chamado pelo frontend quando o atendente abre uma conversa com mensagens
-// pendentes — o badge de unread some na próxima atualização do contact.
-//
-// Lookup do cellphone via Contact.pet_owner_id; UPDATE chat_history em
-// batch onde cell_phone match e is_answered=false. Retorna count atualizado.
-const markAsAnswered = async ({ pet_owner_id }) => {
-  if (!pet_owner_id || !isValidUUID(pet_owner_id)) {
-    throw new Error('pet_owner_id inválido');
+// Aceita `cell_phone` (preferido — todo contact tem) ou `pet_owner_id`
+// (fallback com lookup). Usar só pet_owner_id falha em contacts sem
+// pet_owner vinculado (ex: leads sem pet ainda cadastrado), que é o caso
+// MAIS COMUM quando o atendente abre uma conversa nova.
+const markAsAnswered = async ({ pet_owner_id, cell_phone }) => {
+  let cellphone = cell_phone;
+
+  if (!cellphone && pet_owner_id) {
+    if (!isValidUUID(pet_owner_id)) {
+      throw new Error('pet_owner_id inválido');
+    }
+    const contact = await Contact.findOne({
+      where: { pet_owner_id },
+      attributes: ['cellphone'],
+    });
+    cellphone = contact?.cellphone;
   }
 
-  const contact = await Contact.findOne({
-    where: { pet_owner_id },
-    attributes: ['cellphone'],
-  });
-
-  if (!contact?.cellphone) {
+  if (!cellphone) {
     return { updated: 0, cellphone: null };
   }
 
@@ -302,13 +305,13 @@ const markAsAnswered = async ({ pet_owner_id }) => {
     { is_answered: true },
     {
       where: {
-        cell_phone: contact.cellphone,
+        cell_phone: cellphone,
         is_answered: false,
       },
     },
   );
 
-  return { updated, cellphone: contact.cellphone };
+  return { updated, cellphone };
 };
 
 export default {


### PR DESCRIPTION
Bug fix: contacts sem pet_owner_id (ex: Stella 351965711708 com 24 unanswered) faziam frontend mandar pet_owner_id=undefined → 400 → UPDATE não rolava. Aceita cell_phone como identificador primário.