### PR TITLE
fix(messaging): skip Sequelize validate em ChatHistory.update batch

### DIFF
--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -301,6 +301,13 @@ const markAsAnswered = async ({ pet_owner_id, cell_phone }) => {
     return { updated: 0, cellphone: null };
   }
 
+  // validate: false é OBRIGATÓRIO aqui — o ChatHistoryModel tem o custom
+  // validator `hasContactIdentifier` que exige cell_phone/contact_id/etc.
+  // não-nulos. Em UPDATE batch o Sequelize roda os validators dos campos
+  // sendo atualizados como se fosse criar uma row nova, então rejeita
+  // (é o caso clássico do "ValidationError: Pelo menos um identificador
+  // de contato deve ser fornecido"). Como aqui só tocamos is_answered, é
+  // safe pular validators — nenhuma constraint do banco é riscada.
   const [updated] = await ChatHistory.update(
     { is_answered: true },
     {
@@ -308,6 +315,7 @@ const markAsAnswered = async ({ pet_owner_id, cell_phone }) => {
         cell_phone: cellphone,
         is_answered: false,
       },
+      validate: false,
     },
   );
 


### PR DESCRIPTION
## Causa raiz do badge de unread voltando após F5

O endpoint \`POST /chat-history/messages/markAsAnswered\` (PR #11/#12) retornava **500** silenciosamente:

\`\`\`
ValidationError: Pelo menos um identificador de contato deve ser fornecido
  at model.hasContactIdentifier (ChatHistoryModel.js:157)
  at ChatHistory.update (services/chat-history.service.js:304)
\`\`\`

\`ChatHistoryModel\` tem um custom validator instance-level \`hasContactIdentifier\` que exige \`cell_phone\`/\`contact_id\`/etc não-nulos. Em UPDATE batch (\`Model.update({is_answered: true}, {where})\`), o Sequelize roda os validators dos CAMPOS sendo atualizados como se fosse criar uma row nova — e como o UPDATE só passa \`is_answered: true\`, nenhum identificador "vem", então o validator dispara.

## Por que o N8n não tinha esse bug

O workflow N8n fazia UPDATE Supabase REST direto (\`PATCH /rest/v1/chat_history\`) que IGNORA Sequelize validators (PostgREST → Postgres direto). Migrar pra Sequelize ORM trouxe o validator no caminho.

## Fix
Passar \`validate: false\` no UPDATE. É safe aqui porque só tocamos \`is_answered\` (boolean) — nenhuma constraint do banco é riscada. Os validators continuam rodando em INSERTs/instance saves normalmente.

## Test plan
- [ ] Deploy EC2
- [ ] User abre conversa com badge → contagem zera + sobrevive F5
- [ ] \`SELECT count(*) FROM chat_history WHERE cell_phone='351965711708' AND is_answered=false\` deve ir de 24 → 0 após o user abrir Stella

🤖 Generated with [Claude Code](https://claude.com/claude-code)