### PR TITLE
feat(messaging): paginação dos pedidos do contato via scroll infinito

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -219,6 +219,48 @@ const getContactByContactId = async (req, res) => {
   }
 };
 
+const getOrdersByContactId = async (req, res) => {
+  try {
+    const { contact_id } = req.params;
+    const { page = 1, limit = 10 } = req.query;
+
+    if (!contact_id) {
+      return res.status(400).json({
+        code: 'MISSING_CONTACT_ID',
+        message: 'contact_id is required',
+      });
+    }
+
+    const pageNum = parseInt(page);
+    const limitNum = parseInt(limit);
+
+    if (pageNum < 1 || limitNum < 1 || limitNum > 100) {
+      return res.status(400).json({
+        code: 'INVALID_PAGINATION_PARAMS',
+        message: 'Invalid pagination parameters',
+      });
+    }
+
+    const result = await ChatService.getOrdersByContactId({
+      contact_id,
+      page: pageNum,
+      limit: limitNum,
+    });
+
+    return res.status(200).json({
+      code: 'ORDERS_RETRIEVED',
+      data: result.orders,
+      pagination: result.pagination,
+    });
+  } catch (error) {
+    console.error('Error retrieving orders by contact id:', error);
+    return res.status(500).json({
+      code: 'ORDERS_RETRIEVAL_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getAllContactsMessagesWithNoFilters = async (req, res) => {
   try {
     const { role } = req.user;
@@ -418,6 +460,7 @@ export default {
   getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerId,
   getContactByContactId,
+  getOrdersByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getTestContactsCount,

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -1198,6 +1198,12 @@ const getContactByPetOwnerIdOrPhone = async ({
             {
               model: Order,
               as: 'orders',
+              // separate: true → query SELECT dedicada para orders, permite LIMIT
+              // honesto sem inflar o JOIN principal nem duplicar linhas via items.
+              // Pedidos antigos vêm sob demanda via getOrdersByContactId (scroll
+              // infinito em OrdersHistory.jsx).
+              separate: true,
+              limit: 10,
               attributes: [
                 'id',
                 'marketplace_order_id',
@@ -1419,6 +1425,12 @@ const getContactByPetOwnerId = async ({ pet_owner_id, role, page = 1, limit = 20
             {
               model: Order,
               as: 'orders',
+              // separate: true → query SELECT dedicada para orders, permite LIMIT
+              // honesto sem inflar o JOIN principal nem duplicar linhas via items.
+              // Pedidos antigos vêm sob demanda via getOrdersByContactId (scroll
+              // infinito em OrdersHistory.jsx).
+              separate: true,
+              limit: 10,
               attributes: [
                 'id',
                 'marketplace_order_id',
@@ -1621,6 +1633,12 @@ const getContactByContactId = async ({ contact_id, role, page = 1, limit = 20 })
             {
               model: Order,
               as: 'orders',
+              // separate: true → query SELECT dedicada para orders, permite LIMIT
+              // honesto sem inflar o JOIN principal nem duplicar linhas via items.
+              // Pedidos antigos vêm sob demanda via getOrdersByContactId (scroll
+              // infinito em OrdersHistory.jsx).
+              separate: true,
+              limit: 10,
               attributes: [
                 'id',
                 'marketplace_order_id',
@@ -1669,6 +1687,67 @@ const getContactByContactId = async ({ contact_id, role, page = 1, limit = 20 })
     };
   } catch (error) {
     console.error('❌ ERRO NA FUNÇÃO getContactByContactId:', error.message);
+    console.error('❌ STACK:', error.stack);
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
+// Paginação dos pedidos do contato — alimentada pelo scroll infinito do
+// OrdersHistory.jsx. A primeira página já vem embutida em getContactByContactId
+// (limit:10 no include); este endpoint serve as páginas seguintes (mais antigos).
+const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
+  try {
+    const contact = await Contact.findOne({
+      where: { id: contact_id },
+      attributes: ['id', 'pet_owner_id'],
+    });
+
+    if (!contact?.pet_owner_id) {
+      return {
+        orders: [],
+        pagination: { currentPage: page, limit, totalOrders: 0, hasMore: false, totalPages: 0 },
+      };
+    }
+
+    const offset = (page - 1) * limit;
+
+    const { count, rows } = await Order.findAndCountAll({
+      where: { pet_owner_id: contact.pet_owner_id },
+      attributes: [
+        'id',
+        'marketplace_order_id',
+        'created_at',
+        'total',
+        'current_status_name',
+        'payment_method',
+        'delivery_estimate',
+      ],
+      include: [
+        {
+          model: OrderItem,
+          as: 'items',
+          attributes: ['id', 'name', 'brand', 'category', 'sku', 'thumbnail_url'],
+          required: false,
+        },
+      ],
+      order: [['created_at', 'DESC']],
+      limit,
+      offset,
+      distinct: true,
+    });
+
+    return {
+      orders: rows,
+      pagination: {
+        currentPage: page,
+        limit,
+        totalOrders: count,
+        hasMore: count > page * limit,
+        totalPages: Math.ceil(count / limit),
+      },
+    };
+  } catch (error) {
+    console.error('❌ ERRO NA FUNÇÃO getOrdersByContactId:', error.message);
     console.error('❌ STACK:', error.stack);
     throw new Error(`Repository error: ${error.message}`);
   }
@@ -1975,5 +2054,6 @@ export default {
   getContactByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllContactsMessagesWithNoFilters,
+  getOrdersByContactId,
   getTestContactsCount,
 };

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -54,6 +54,13 @@ router.get(
 );
 
 router.get(
+  '/messages/orders/by-contact/:contact_id',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getOrdersByContactId,
+);
+
+router.get(
   '/messages/getContactByPetOwnerIdOrPhone',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'attendant']),

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -217,6 +217,14 @@ const getContactByContactId = async ({ contact_id, role, page = 1, limit = 20 })
   }
 };
 
+const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
+  try {
+    return await ChatRepository.getOrdersByContactId({ contact_id, page, limit });
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
 const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 15 }) => {
   try {
     const result = await ChatRepository.getAllContactsMessagesWithNoFilters({
@@ -328,6 +336,7 @@ export default {
   searchContacts,
   getContactByPetOwnerId,
   getContactByContactId,
+  getOrdersByContactId,
   getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,


### PR DESCRIPTION
## Por quê

Abrir o chat de um contato com muitos pedidos (100+) ficava lento: o include de `orders` em `getContactByContactId` e `getContactByPetOwnerId` trazia **todos** os pedidos do contato com JOIN em items, sem LIMIT.

## O que muda

**Includes de orders nos 3 handlers de detail** (`getContactByPetOwnerId` x2 + `getContactByContactId`):
- `separate: true` + `limit: 10` — Sequelize faz uma SELECT dedicada para orders, com LIMIT honesto, sem inflar o JOIN principal nem duplicar linhas via items.
- Ordenação `created_at DESC` mantida.

**Novo endpoint paginado** consumido pelo scroll infinito do frontend:
```
GET /chat-history/messages/orders/by-contact/:contact_id?page=N&limit=10
→ { code, data: orders[], pagination: { currentPage, limit, totalOrders, hasMore, totalPages } }
```

PR companion no frontend: https://github.com/Latta-app/frontend/pull/new/feat/messaging-orders-pagination

## Test plan
- [ ] Abrir chat de contato com muitos pedidos — primeira tela carrega só 10 mais recentes
- [ ] No frontend, scrollar lista de pedidos no painel direito → próximas páginas chegam ordenadas DESC
- [ ] Conferir 401 sem token, 200 com token de attendant/admin/superAdmin
- [ ] `hasMore: false` na última página

🤖 Generated with [Claude Code](https://claude.com/claude-code)