### PR TITLE
feat(dashboard): suporte a window/phone/refresh + rotas abandoned e drilldown

### DIFF
--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -1,9 +1,14 @@
 import DashboardService from '../services/dashboard.service.js';
 
+const parseRefresh = (q) => q?.refresh === '1' || q?.refresh === 'true';
+
 const getDashboardSummary = async (req, res) => {
   try {
-    const refresh = req.query.refresh === '1' || req.query.refresh === 'true';
-    const summary = await DashboardService.getDashboardSummary({ refresh });
+    const summary = await DashboardService.getDashboardSummary({
+      window: req.query.window,
+      phone: req.query.phone,
+      refresh: parseRefresh(req.query),
+    });
 
     return res.status(200).json({
       code: 'DASHBOARD_SUMMARY_RETRIEVED',
@@ -18,4 +23,52 @@ const getDashboardSummary = async (req, res) => {
   }
 };
 
-export default { getDashboardSummary };
+const getAbandonedFlows = async (req, res) => {
+  try {
+    const result = await DashboardService.getAbandonedFlows({
+      window: req.query.window,
+      refresh: parseRefresh(req.query),
+    });
+
+    return res.status(200).json({
+      code: 'DASHBOARD_ABANDONED_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Erro ao buscar dashboard abandoned:', error);
+    return res.status(500).json({
+      code: 'DASHBOARD_ABANDONED_ERROR',
+      message: error.message,
+    });
+  }
+};
+
+const getContactDrilldown = async (req, res) => {
+  try {
+    const phone = req.params.phone || req.query.phone;
+    if (!phone) {
+      return res.status(400).json({
+        code: 'DASHBOARD_DRILLDOWN_PHONE_REQUIRED',
+        message: 'phone é obrigatório',
+      });
+    }
+    const result = await DashboardService.getContactDrilldown({ phone });
+
+    return res.status(200).json({
+      code: 'DASHBOARD_DRILLDOWN_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Erro ao buscar dashboard drilldown:', error);
+    return res.status(500).json({
+      code: 'DASHBOARD_DRILLDOWN_ERROR',
+      message: error.message,
+    });
+  }
+};
+
+export default {
+  getDashboardSummary,
+  getAbandonedFlows,
+  getContactDrilldown,
+};

--- a/src/api/routes/private/dashboard.routes.js
+++ b/src/api/routes/private/dashboard.routes.js
@@ -3,12 +3,27 @@ import DashboardController from '../../controllers/dashboard.controller.js';
 import { verifyToken, checkRole } from '../../middlewares/auth.middleware.js';
 
 const router = Router();
+const ALLOWED = ['admin', 'superAdmin', 'attendant'];
 
 router.get(
   '/summary',
   verifyToken,
-  checkRole(['admin', 'superAdmin', 'attendant']),
+  checkRole(ALLOWED),
   DashboardController.getDashboardSummary,
+);
+
+router.get(
+  '/abandoned',
+  verifyToken,
+  checkRole(ALLOWED),
+  DashboardController.getAbandonedFlows,
+);
+
+router.get(
+  '/contact/:phone',
+  verifyToken,
+  checkRole(ALLOWED),
+  DashboardController.getContactDrilldown,
 );
 
 export default router;

--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -3,13 +3,37 @@ const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 const DASHBOARD_METRICS_URL = `${SUPABASE_URL}/functions/v1/dashboard-metrics`;
 
-const getDashboardSummary = async ({ refresh = false } = {}) => {
+const ALLOWED_WINDOWS = new Set(['24h', '7d', '30d', '90d']);
+const ALLOWED_ACTIONS = new Set(['summary', 'abandoned', 'drilldown']);
+
+const buildUrl = ({ action, window, phone, refresh }) => {
+  const params = new URLSearchParams();
+  if (action && action !== 'summary') params.set('action', action);
+  if (window) params.set('window', window);
+  if (phone) params.set('phone', phone);
+  if (refresh) params.set('refresh', '1');
+  const query = params.toString();
+  return query ? `${DASHBOARD_METRICS_URL}?${query}` : DASHBOARD_METRICS_URL;
+};
+
+const callDashboardMetrics = async ({ action = 'summary', window, phone, refresh = false } = {}) => {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
     throw new Error('SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY são obrigatórios');
   }
+  if (!ALLOWED_ACTIONS.has(action)) {
+    throw new Error(`action inválida: ${action}`);
+  }
+  if (window && !ALLOWED_WINDOWS.has(window)) {
+    throw new Error(`window inválida: ${window}`);
+  }
+  if (action === 'drilldown' && !phone) {
+    throw new Error('phone é obrigatório para drilldown');
+  }
+  if (phone && !/^\d{10,15}$/.test(phone)) {
+    throw new Error('phone inválido (apenas dígitos, 10-15)');
+  }
 
-  const url = refresh ? `${DASHBOARD_METRICS_URL}?refresh=1` : DASHBOARD_METRICS_URL;
-
+  const url = buildUrl({ action, window, phone, refresh });
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -26,4 +50,17 @@ const getDashboardSummary = async ({ refresh = false } = {}) => {
   return res.json();
 };
 
-export default { getDashboardSummary };
+const getDashboardSummary = async ({ window, phone, refresh } = {}) =>
+  callDashboardMetrics({ action: 'summary', window, phone, refresh });
+
+const getAbandonedFlows = async ({ window, refresh } = {}) =>
+  callDashboardMetrics({ action: 'abandoned', window, refresh });
+
+const getContactDrilldown = async ({ phone } = {}) =>
+  callDashboardMetrics({ action: 'drilldown', phone });
+
+export default {
+  getDashboardSummary,
+  getAbandonedFlows,
+  getContactDrilldown,
+};


### PR DESCRIPTION
## Summary
Backend agora expõe 3 rotas pro painel operacional:
- \`GET /admin/dashboard/summary?window=24h|7d|30d|90d&phone=&refresh=1\`
- \`GET /admin/dashboard/abandoned?window=...&refresh=1\`
- \`GET /admin/dashboard/contact/:phone\` (drilldown lateral)

Validação no service: window allowlist, phone só dígitos 10-15, drilldown exige phone.

## Test plan
- [x] \`node --check\` syntax OK nas 3 rotas
- [x] Smoke test em dev (port 9125) com JWT superAdmin: 3 rotas retornam 200 com payload completo
- [ ] Após deploy: smoke test em prod
- [ ] Frontend (PR irmão) consome essas rotas

## Depende de
- Main repo PR #238 (RPCs + EF dashboard-metrics v2) — JÁ MERGEADO

🤖 Generated with [Claude Code](https://claude.com/claude-code)