### PR TITLE
feat(dashboard): rota /admin/dashboard/funnel/:step proxy pra EF v3

### DIFF
--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -43,6 +43,34 @@ const getAbandonedFlows = async (req, res) => {
   }
 };
 
+const getFunnelStep = async (req, res) => {
+  try {
+    const step = req.params.step || req.query.step;
+    if (!step) {
+      return res.status(400).json({
+        code: 'DASHBOARD_FUNNEL_STEP_REQUIRED',
+        message: 'step é obrigatório',
+      });
+    }
+    const result = await DashboardService.getFunnelStep({
+      step,
+      window: req.query.window,
+      refresh: parseRefresh(req.query),
+    });
+
+    return res.status(200).json({
+      code: 'DASHBOARD_FUNNEL_STEP_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Erro ao buscar funnel step:', error);
+    return res.status(500).json({
+      code: 'DASHBOARD_FUNNEL_STEP_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getContactDrilldown = async (req, res) => {
   try {
     const phone = req.params.phone || req.query.phone;
@@ -71,4 +99,5 @@ export default {
   getDashboardSummary,
   getAbandonedFlows,
   getContactDrilldown,
+  getFunnelStep,
 };

--- a/src/api/routes/private/dashboard.routes.js
+++ b/src/api/routes/private/dashboard.routes.js
@@ -20,6 +20,13 @@ router.get(
 );
 
 router.get(
+  '/funnel/:step',
+  verifyToken,
+  checkRole(ALLOWED),
+  DashboardController.getFunnelStep,
+);
+
+router.get(
   '/contact/:phone',
   verifyToken,
   checkRole(ALLOWED),

--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -4,19 +4,38 @@ const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const DASHBOARD_METRICS_URL = `${SUPABASE_URL}/functions/v1/dashboard-metrics`;
 
 const ALLOWED_WINDOWS = new Set(['24h', '7d', '30d', '90d']);
-const ALLOWED_ACTIONS = new Set(['summary', 'abandoned', 'drilldown']);
+const ALLOWED_ACTIONS = new Set([
+  'summary',
+  'abandoned',
+  'drilldown',
+  'funnel_step',
+]);
+const ALLOWED_FUNNEL_STEPS = new Set([
+  'talked',
+  'onboarded',
+  'utilized',
+  'purchased',
+  'pro',
+]);
 
-const buildUrl = ({ action, window, phone, refresh }) => {
+const buildUrl = ({ action, window, phone, step, refresh }) => {
   const params = new URLSearchParams();
   if (action && action !== 'summary') params.set('action', action);
   if (window) params.set('window', window);
   if (phone) params.set('phone', phone);
+  if (step) params.set('step', step);
   if (refresh) params.set('refresh', '1');
   const query = params.toString();
   return query ? `${DASHBOARD_METRICS_URL}?${query}` : DASHBOARD_METRICS_URL;
 };
 
-const callDashboardMetrics = async ({ action = 'summary', window, phone, refresh = false } = {}) => {
+const callDashboardMetrics = async ({
+  action = 'summary',
+  window,
+  phone,
+  step,
+  refresh = false,
+} = {}) => {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
     throw new Error('SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY são obrigatórios');
   }
@@ -29,11 +48,17 @@ const callDashboardMetrics = async ({ action = 'summary', window, phone, refresh
   if (action === 'drilldown' && !phone) {
     throw new Error('phone é obrigatório para drilldown');
   }
+  if (action === 'funnel_step') {
+    if (!step) throw new Error('step é obrigatório para funnel_step');
+    if (!ALLOWED_FUNNEL_STEPS.has(step)) {
+      throw new Error(`step inválido: ${step}`);
+    }
+  }
   if (phone && !/^\d{10,15}$/.test(phone)) {
     throw new Error('phone inválido (apenas dígitos, 10-15)');
   }
 
-  const url = buildUrl({ action, window, phone, refresh });
+  const url = buildUrl({ action, window, phone, step, refresh });
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -59,8 +84,12 @@ const getAbandonedFlows = async ({ window, refresh } = {}) =>
 const getContactDrilldown = async ({ phone } = {}) =>
   callDashboardMetrics({ action: 'drilldown', phone });
 
+const getFunnelStep = async ({ step, window, refresh } = {}) =>
+  callDashboardMetrics({ action: 'funnel_step', step, window, refresh });
+
 export default {
   getDashboardSummary,
   getAbandonedFlows,
   getContactDrilldown,
+  getFunnelStep,
 };


### PR DESCRIPTION
## Summary
- Adiciona rota `GET /admin/dashboard/funnel/:step` proxiando pro novo endpoint `funnel_step` da EF `dashboard-metrics` v3.
- Habilita "todo número clicável" no cockpit estratégico do frontend.

## Mudanças
- `dashboard.service.js`: aceita action `funnel_step` + valida step (`talked`/`onboarded`/`utilized`/`purchased`/`pro`).
- `dashboard.controller.js`: handler `getFunnelStep` (segue padrão dos outros).
- `dashboard.routes.js`: rota `GET /funnel/:step` com middlewares verifyToken + checkRole.

## Dependências
- PR principal (Supabase) precisa estar mergeado antes deste deploy: https://github.com/Matheus3FY/Latta/pull/246
- A EF `dashboard-metrics` deve estar deployada em produção (já contém suporte a `action=funnel_step`).

## Test plan
- [ ] Deploy backend após PR principal mergeado
- [ ] `GET /api/admin/dashboard/funnel/talked?window=24h` retorna 200 com `data.phones`
- [ ] `GET /api/admin/dashboard/funnel/invalid_step` retorna 500 com erro descritivo
- [ ] Frontend cockpit consegue abrir painel lateral ao clicar nos degraus do funil

🤖 Generated with [Claude Code](https://claude.com/claude-code)