### PR TITLE
feat(dashboard): rota /admin/dashboard/search (busca aproximada)

### DIFF
--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -43,6 +43,29 @@ const getAbandonedFlows = async (req, res) => {
   }
 };
 
+const searchPhone = async (req, res) => {
+  try {
+    const q = req.query.q || req.params.q;
+    if (!q) {
+      return res.status(400).json({
+        code: 'DASHBOARD_SEARCH_QUERY_REQUIRED',
+        message: 'q é obrigatório',
+      });
+    }
+    const result = await DashboardService.searchPhone({ q });
+    return res.status(200).json({
+      code: 'DASHBOARD_SEARCH_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Erro ao buscar phone:', error);
+    return res.status(500).json({
+      code: 'DASHBOARD_SEARCH_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getFunnelStep = async (req, res) => {
   try {
     const step = req.params.step || req.query.step;
@@ -100,4 +123,5 @@ export default {
   getAbandonedFlows,
   getContactDrilldown,
   getFunnelStep,
+  searchPhone,
 };

--- a/src/api/routes/private/dashboard.routes.js
+++ b/src/api/routes/private/dashboard.routes.js
@@ -20,6 +20,13 @@ router.get(
 );
 
 router.get(
+  '/search',
+  verifyToken,
+  checkRole(ALLOWED),
+  DashboardController.searchPhone,
+);
+
+router.get(
   '/funnel/:step',
   verifyToken,
   checkRole(ALLOWED),

--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -9,6 +9,7 @@ const ALLOWED_ACTIONS = new Set([
   'abandoned',
   'drilldown',
   'funnel_step',
+  'search',
 ]);
 const ALLOWED_FUNNEL_STEPS = new Set([
   'talked',
@@ -18,12 +19,13 @@ const ALLOWED_FUNNEL_STEPS = new Set([
   'pro',
 ]);
 
-const buildUrl = ({ action, window, phone, step, refresh }) => {
+const buildUrl = ({ action, window, phone, step, q, refresh }) => {
   const params = new URLSearchParams();
   if (action && action !== 'summary') params.set('action', action);
   if (window) params.set('window', window);
   if (phone) params.set('phone', phone);
   if (step) params.set('step', step);
+  if (q) params.set('q', q);
   if (refresh) params.set('refresh', '1');
   const query = params.toString();
   return query ? `${DASHBOARD_METRICS_URL}?${query}` : DASHBOARD_METRICS_URL;
@@ -34,6 +36,7 @@ const callDashboardMetrics = async ({
   window,
   phone,
   step,
+  q,
   refresh = false,
 } = {}) => {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
@@ -57,8 +60,13 @@ const callDashboardMetrics = async ({
   if (phone && !/^\d{10,15}$/.test(phone)) {
     throw new Error('phone inválido (apenas dígitos, 10-15)');
   }
+  if (action === 'search') {
+    if (!q) throw new Error('q é obrigatório para search');
+    const digits = String(q).replace(/\D/g, '');
+    if (digits.length < 6) throw new Error('q deve ter pelo menos 6 dígitos');
+  }
 
-  const url = buildUrl({ action, window, phone, step, refresh });
+  const url = buildUrl({ action, window, phone, step, q, refresh });
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -87,9 +95,13 @@ const getContactDrilldown = async ({ phone } = {}) =>
 const getFunnelStep = async ({ step, window, refresh } = {}) =>
   callDashboardMetrics({ action: 'funnel_step', step, window, refresh });
 
+const searchPhone = async ({ q } = {}) =>
+  callDashboardMetrics({ action: 'search', q });
+
 export default {
   getDashboardSummary,
   getAbandonedFlows,
   getContactDrilldown,
   getFunnelStep,
+  searchPhone,
 };


### PR DESCRIPTION
## Summary
Adiciona rota `GET /admin/dashboard/search?q=<digits>` proxiando pra nova action `search` da EF dashboard-metrics. Permite busca por trecho de phone (ex: `999155797` encontra `31999155797`).

## Validação
- `q` mínimo 6 dígitos (regex `\D` removido)
- Sem cache (resultado pequeno + busca diferente a cada chamada)

## Dependências
- Supabase main repo: PR com hotfix RPC + EF
- Frontend: PR de UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)