### PR TITLE
feat(dashboard): rota pro-revenue-channels

### DIFF
--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -146,11 +146,31 @@ const getOnboardingFunnel = async (req, res) => {
   }
 };
 
+const getProRevenueChannels = async (req, res) => {
+  try {
+    const result = await DashboardService.getProRevenueChannels({
+      refresh: parseRefresh(req.query),
+    });
+
+    return res.status(200).json({
+      code: 'DASHBOARD_PRO_REVENUE_CHANNELS_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Erro ao buscar dashboard pro revenue channels:', error);
+    return res.status(500).json({
+      code: 'DASHBOARD_PRO_REVENUE_CHANNELS_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   getDashboardSummary,
   getAbandonedFlows,
   getContactDrilldown,
   getFunnelStep,
   getOnboardingFunnel,
+  getProRevenueChannels,
   searchPhone,
 };

--- a/src/api/routes/private/dashboard.routes.js
+++ b/src/api/routes/private/dashboard.routes.js
@@ -41,6 +41,13 @@ router.get(
 );
 
 router.get(
+  '/pro-revenue-channels',
+  verifyToken,
+  checkRole(ALLOWED),
+  DashboardController.getProRevenueChannels,
+);
+
+router.get(
   '/contact/:phone',
   verifyToken,
   checkRole(ALLOWED),

--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -10,6 +10,7 @@ const ALLOWED_ACTIONS = new Set([
   'drilldown',
   'funnel_step',
   'onboarding_funnel',
+  'pro_revenue_channels',
   'search',
 ]);
 const ALLOWED_FUNNEL_STEPS = new Set([
@@ -120,6 +121,9 @@ const getFunnelStep = async ({ step, window, scope, refresh } = {}) =>
 const getOnboardingFunnel = async ({ window, scope, isPro, refresh } = {}) =>
   callDashboardMetrics({ action: 'onboarding_funnel', window, scope, isPro, refresh });
 
+const getProRevenueChannels = async ({ refresh } = {}) =>
+  callDashboardMetrics({ action: 'pro_revenue_channels', refresh });
+
 const searchPhone = async ({ q } = {}) =>
   callDashboardMetrics({ action: 'search', q });
 
@@ -129,5 +133,6 @@ export default {
   getContactDrilldown,
   getFunnelStep,
   getOnboardingFunnel,
+  getProRevenueChannels,
   searchPhone,
 };


### PR DESCRIPTION
## Summary
\`GET /admin/dashboard/pro-revenue-channels\` que delega pra EF \`dashboard-metrics\` action=\`pro_revenue_channels\`. Mesmos roles do dashboard. Sem params (snapshot atual).

Depende do PR monorepo (Matheus3FY/Latta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)