### PR TITLE
feat(dashboard): rota cohort-retention

### DIFF
--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -165,6 +165,29 @@ const getProRevenueChannels = async (req, res) => {
   }
 };
 
+const getCohortRetention = async (req, res) => {
+  try {
+    const lookbackRaw = req.query.lookback_days;
+    const lookbackDays = lookbackRaw != null ? parseInt(lookbackRaw, 10) : undefined;
+
+    const result = await DashboardService.getCohortRetention({
+      lookbackDays: Number.isFinite(lookbackDays) ? lookbackDays : undefined,
+      refresh: parseRefresh(req.query),
+    });
+
+    return res.status(200).json({
+      code: 'DASHBOARD_COHORT_RETENTION_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Erro ao buscar dashboard cohort retention:', error);
+    return res.status(500).json({
+      code: 'DASHBOARD_COHORT_RETENTION_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   getDashboardSummary,
   getAbandonedFlows,
@@ -172,5 +195,6 @@ export default {
   getFunnelStep,
   getOnboardingFunnel,
   getProRevenueChannels,
+  getCohortRetention,
   searchPhone,
 };

--- a/src/api/routes/private/dashboard.routes.js
+++ b/src/api/routes/private/dashboard.routes.js
@@ -48,6 +48,13 @@ router.get(
 );
 
 router.get(
+  '/cohort-retention',
+  verifyToken,
+  checkRole(ALLOWED),
+  DashboardController.getCohortRetention,
+);
+
+router.get(
   '/contact/:phone',
   verifyToken,
   checkRole(ALLOWED),

--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -11,6 +11,7 @@ const ALLOWED_ACTIONS = new Set([
   'funnel_step',
   'onboarding_funnel',
   'pro_revenue_channels',
+  'cohort_retention',
   'search',
 ]);
 const ALLOWED_FUNNEL_STEPS = new Set([
@@ -29,7 +30,17 @@ const ALLOWED_FUNNEL_STEPS = new Set([
 ]);
 const ALLOWED_ONBOARDING_SCOPES = new Set(['cohort', 'all']);
 
-const buildUrl = ({ action, window, phone, step, scope, q, isPro, refresh }) => {
+const buildUrl = ({
+  action,
+  window,
+  phone,
+  step,
+  scope,
+  q,
+  isPro,
+  lookbackDays,
+  refresh,
+}) => {
   const params = new URLSearchParams();
   if (action && action !== 'summary') params.set('action', action);
   if (window) params.set('window', window);
@@ -39,6 +50,7 @@ const buildUrl = ({ action, window, phone, step, scope, q, isPro, refresh }) => 
   if (q) params.set('q', q);
   if (isPro === true) params.set('is_pro', 'true');
   else if (isPro === false) params.set('is_pro', 'false');
+  if (lookbackDays != null) params.set('lookback_days', String(lookbackDays));
   if (refresh) params.set('refresh', '1');
   const query = params.toString();
   return query ? `${DASHBOARD_METRICS_URL}?${query}` : DASHBOARD_METRICS_URL;
@@ -52,6 +64,7 @@ const callDashboardMetrics = async ({
   scope,
   q,
   isPro,
+  lookbackDays,
   refresh = false,
 } = {}) => {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
@@ -89,7 +102,7 @@ const callDashboardMetrics = async ({
     if (digits.length < 6) throw new Error('q deve ter pelo menos 6 dígitos');
   }
 
-  const url = buildUrl({ action, window, phone, step, scope, q, isPro, refresh });
+  const url = buildUrl({ action, window, phone, step, scope, q, isPro, lookbackDays, refresh });
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -124,6 +137,9 @@ const getOnboardingFunnel = async ({ window, scope, isPro, refresh } = {}) =>
 const getProRevenueChannels = async ({ refresh } = {}) =>
   callDashboardMetrics({ action: 'pro_revenue_channels', refresh });
 
+const getCohortRetention = async ({ lookbackDays, refresh } = {}) =>
+  callDashboardMetrics({ action: 'cohort_retention', lookbackDays, refresh });
+
 const searchPhone = async ({ q } = {}) =>
   callDashboardMetrics({ action: 'search', q });
 
@@ -134,5 +150,6 @@ export default {
   getFunnelStep,
   getOnboardingFunnel,
   getProRevenueChannels,
+  getCohortRetention,
   searchPhone,
 };


### PR DESCRIPTION
## Summary
\`GET /admin/dashboard/cohort-retention?lookback_days=N\` que delega pra EF \`cohort_retention\`. Param opcional \`lookback_days\` (default 90, clamped [7, 365]). Mesmos roles do dashboard.

Depende do PR monorepo (Matheus3FY/Latta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)