### PR TITLE
feat(dashboard): aceitar step 'messaged' em ALLOWED_FUNNEL_STEPS

### DIFF
--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -21,7 +21,8 @@ const ALLOWED_FUNNEL_STEPS = new Set([
   'utilized',
   'purchased',
   'pro',
-  // Steps internos do Onboarding V3
+  // Steps internos do Onboarding V3 (cohort base = contacts criados na janela)
+  'messaged',
   'pet_registered',
   'pet_confirmed',
   'pro_decision',


### PR DESCRIPTION
Whitelist do drill-down agora aceita o novo step 'messaged'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)