### PR TITLE
feat(backend): setAttendance endpoint pra mensageria humana

### DIFF
--- a/src/api/controllers/contact.controller.js
+++ b/src/api/controllers/contact.controller.js
@@ -26,6 +26,44 @@ const toggleAttendance = async (req, res) => {
   }
 };
 
+const setAttendance = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { is_being_attended } = req.body;
+
+    if (!id) {
+      return res.status(400).json({
+        code: 'MISSING_CONTACT_ID',
+        message: 'contact_id is required',
+      });
+    }
+
+    if (typeof is_being_attended !== 'boolean') {
+      return res.status(400).json({
+        code: 'INVALID_ATTENDANCE_FLAG',
+        message: 'is_being_attended must be boolean',
+      });
+    }
+
+    const result = await ContactService.setAttendance({
+      contact_id: id,
+      is_being_attended,
+    });
+
+    return res.status(200).json({
+      code: 'ATTENDANCE_SET',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Error setting attendance:', error);
+    return res.status(500).json({
+      code: 'ATTENDANCE_SET_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   toggleAttendance,
+  setAttendance,
 };

--- a/src/api/repositories/contact.repository.js
+++ b/src/api/repositories/contact.repository.js
@@ -20,6 +20,30 @@ const toggleAttendance = async ({ contact_id }) => {
   }
 };
 
+// Set explicit (no toggle) — usado quando Luma envia mensagem/template pelo
+// painel: o ato de envio força is_being_attended=true, evitando que a Lattinha
+// (bot) responda a próxima inbound do tutor.
+const setAttendance = async ({ contact_id, is_being_attended }) => {
+  try {
+    const contact = await Contact.findByPk(contact_id);
+
+    if (!contact) {
+      throw new Error('Contact not found');
+    }
+
+    contact.is_being_attended = !!is_being_attended;
+    await contact.save();
+
+    return {
+      id: contact.id,
+      is_being_attended: contact.is_being_attended,
+    };
+  } catch (error) {
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 export default {
   toggleAttendance,
+  setAttendance,
 };

--- a/src/api/routes/private/contact.routes.js
+++ b/src/api/routes/private/contact.routes.js
@@ -11,4 +11,14 @@ router.patch(
   ContactController.toggleAttendance,
 );
 
+// Set explicit (não toggle) — usado quando o painel envia mensagem/template
+// pela Luma e precisa garantir is_being_attended=true sem depender do estado
+// anterior. Toggle continua existindo pra controle manual via dropdown.
+router.patch(
+  '/:id/attendance',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ContactController.setAttendance,
+);
+
 export default router;

--- a/src/api/services/contact.service.js
+++ b/src/api/services/contact.service.js
@@ -9,6 +9,16 @@ const toggleAttendance = async ({ contact_id }) => {
   }
 };
 
+const setAttendance = async ({ contact_id, is_being_attended }) => {
+  try {
+    const result = await ContactRepository.setAttendance({ contact_id, is_being_attended });
+    return result;
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
 export default {
   toggleAttendance,
+  setAttendance,
 };


### PR DESCRIPTION
## Summary

Adiciona endpoint `PATCH /contacts/:id/attendance` que aceita `{ is_being_attended: boolean }` no body — set explícito, sem toggle.

## Por que

Quando a operadora **Luma** envia mensagem ou template pelo painel, o ato de envio precisa garantir que `contacts.is_being_attended = true` independente do estado anterior. O endpoint `toggle-attendance` existente vira o boolean (era `false` → vira `true`, era `true` → vira `false`), o que é errado pra esse caso.

Toggle continua existindo pra o controle manual via dropdown "Trocar responsável" no header do chat.

## Arquivos

- `src/api/controllers/contact.controller.js` — handler `setAttendance(req, res)` com validação
- `src/api/services/contact.service.js` — passthrough pro repository
- `src/api/repositories/contact.repository.js` — `setAttendance({ contact_id, is_being_attended })` com `findByPk` + `save()`
- `src/api/routes/private/contact.routes.js` — rota `PATCH /:id/attendance` com `verifyToken` + `checkRole(['admin','superAdmin','attendant'])`

## Pareado com

- Frontend PR `Latta-app/frontend#feat/messaging-luma-rebrand` (consome o endpoint via `ChatService.setAttendance`)
- Latta principal PR `Matheus3FY/Latta#feat/messaging-luma-rebrand` (templates novos + workflows N8n com rebrand Petland → Luma)

Mergeiam juntos. Sem o frontend, o endpoint não é chamado; sem o endpoint, o frontend dá 404.

## Test plan

- [ ] `npm run dev` sobe sem erro
- [ ] `curl -X PATCH /contacts/{id}/attendance -d '{"is_being_attended": true}'` retorna 200
- [ ] `curl ... -d '{"is_being_attended": "string"}'` retorna 400 `INVALID_ATTENDANCE_FLAG`
- [ ] `curl ... -d '{}'` retorna 400 `INVALID_ATTENDANCE_FLAG`
- [ ] Após deploy, painel envia mensagem → contact.is_being_attended vira `true` no DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)