### PR TITLE
feat(backend): propaga includeTest em dashboard summary e abandoned

### DIFF
--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -8,6 +8,7 @@ const getDashboardSummary = async (req, res) => {
     const summary = await DashboardService.getDashboardSummary({
       window: req.query.window,
       phone: req.query.phone,
+      includeTest: parseIncludeTest(req.query),
       refresh: parseRefresh(req.query),
     });
 
@@ -28,6 +29,7 @@ const getAbandonedFlows = async (req, res) => {
   try {
     const result = await DashboardService.getAbandonedFlows({
       window: req.query.window,
+      includeTest: parseIncludeTest(req.query),
       refresh: parseRefresh(req.query),
     });
 

--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -134,11 +134,11 @@ const callDashboardMetrics = async ({
   return res.json();
 };
 
-const getDashboardSummary = async ({ window, phone, refresh } = {}) =>
-  callDashboardMetrics({ action: 'summary', window, phone, refresh });
+const getDashboardSummary = async ({ window, phone, includeTest, refresh } = {}) =>
+  callDashboardMetrics({ action: 'summary', window, phone, includeTest, refresh });
 
-const getAbandonedFlows = async ({ window, refresh } = {}) =>
-  callDashboardMetrics({ action: 'abandoned', window, refresh });
+const getAbandonedFlows = async ({ window, includeTest, refresh } = {}) =>
+  callDashboardMetrics({ action: 'abandoned', window, includeTest, refresh });
 
 const getContactDrilldown = async ({ phone } = {}) =>
   callDashboardMetrics({ action: 'drilldown', phone });


### PR DESCRIPTION
## Summary
- Controllers getDashboardSummary e getAbandonedFlows parseiam include_test=true da query string.
- Service propaga includeTest pra EF dashboard-metrics.

Fecha o caminho cliente → backend → EF pra Modo Dev cobrir TODAS as métricas (antes só funis/MRR/cohort respondiam).

## Test plan
- [ ] Subir backend com mudança
- [ ] curl /admin/dashboard/summary?window=24h → real
- [ ] curl /admin/dashboard/summary?window=24h&include_test=true → dev (test-personas incluídas)
- [ ] Mesmo pra /admin/dashboard/abandoned

🤖 Generated with [Claude Code](https://claude.com/claude-code)