### PR TITLE
feat(backend): Fase 4 — tags + responsibility + thumbs + AI suggestion no Express

### DIFF
--- a/src/api/controllers/ai-feedback.controller.js
+++ b/src/api/controllers/ai-feedback.controller.js
@@ -1,0 +1,34 @@
+import AIFeedbackService from '../services/ai-feedback.service.js';
+
+const setThumbs = async (req, res) => {
+  try {
+    const { cell_phone, thumbs } = req.body;
+    if (!cell_phone) {
+      return res.status(400).json({
+        code: 'MISSING_CELL_PHONE',
+        message: 'cell_phone is required',
+      });
+    }
+    if (thumbs !== 'up' && thumbs !== 'down') {
+      return res.status(400).json({
+        code: 'INVALID_THUMBS',
+        message: 'thumbs must be "up" or "down"',
+      });
+    }
+    const result = await AIFeedbackService.setThumbs({ cell_phone, thumbs });
+    return res.status(200).json({
+      code: 'AI_FEEDBACK_RECORDED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Error recording AI feedback:', error);
+    return res.status(500).json({
+      code: 'AI_FEEDBACK_ERROR',
+      message: error.message,
+    });
+  }
+};
+
+export default {
+  setThumbs,
+};

--- a/src/api/controllers/contact.controller.js
+++ b/src/api/controllers/contact.controller.js
@@ -63,7 +63,36 @@ const setAttendance = async (req, res) => {
   }
 };
 
+const setResponsibility = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { user_id, path } = req.body;
+    if (!id) {
+      return res.status(400).json({
+        code: 'MISSING_CONTACT_ID',
+        message: 'contact_id is required',
+      });
+    }
+    const result = await ContactService.setResponsibility({
+      contact_id: id,
+      user_id: user_id || null,
+      path: path || null,
+    });
+    return res.status(200).json({
+      code: 'RESPONSIBILITY_SET',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Error setting responsibility:', error);
+    return res.status(500).json({
+      code: 'RESPONSIBILITY_SET_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   toggleAttendance,
   setAttendance,
+  setResponsibility,
 };

--- a/src/api/controllers/messaging.controller.js
+++ b/src/api/controllers/messaging.controller.js
@@ -75,7 +75,43 @@ const sendTemplate = async (req, res) => {
   }
 };
 
+const sendAISuggestion = async (req, res) => {
+  try {
+    const { contact_id, message, is_modificated } = req.body;
+    const userId = req.user?.id || null;
+    if (!contact_id) {
+      return res.status(400).json({
+        code: 'MISSING_CONTACT_ID',
+        message: 'contact_id is required',
+      });
+    }
+    if (!message || typeof message !== 'string' || !message.trim()) {
+      return res.status(400).json({
+        code: 'MISSING_MESSAGE',
+        message: 'message is required',
+      });
+    }
+    const result = await MessagingService.sendAISuggestion({
+      contact_id,
+      message: message.trim(),
+      is_modificated: !!is_modificated,
+      user_id: userId,
+    });
+    return res.status(200).json({
+      code: 'AI_SUGGESTION_SENT',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Error sending AI suggestion:', error);
+    return res.status(500).json({
+      code: 'AI_SUGGESTION_SEND_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   sendText,
   sendTemplate,
+  sendAISuggestion,
 };

--- a/src/api/controllers/tag.controller.js
+++ b/src/api/controllers/tag.controller.js
@@ -1,5 +1,34 @@
 import TagService from '../services/tag.service.js';
 
+// Migrado do webhook N8n /tags. Body: { pet_owner_id, create: [tag_id...],
+// delete: [tag_id...] }. Aplica em batch: idempotente em ambos.
+const manageAssignments = async (req, res) => {
+  try {
+    const { pet_owner_id, create, delete: toDelete } = req.body;
+    if (!pet_owner_id) {
+      return res.status(400).json({
+        code: 'MISSING_PET_OWNER_ID',
+        message: 'pet_owner_id is required',
+      });
+    }
+    const result = await TagService.manageAssignments({
+      pet_owner_id,
+      create,
+      delete: toDelete,
+    });
+    return res.status(200).json({
+      code: 'TAG_ASSIGNMENTS_UPDATED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Error managing tag assignments:', error);
+    return res.status(500).json({
+      code: 'TAG_ASSIGNMENTS_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getAllTags = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
@@ -159,4 +188,5 @@ export default {
   updateTag,
   deleteTag,
   searchTags,
+  manageAssignments,
 };

--- a/src/api/repositories/contact.repository.js
+++ b/src/api/repositories/contact.repository.js
@@ -43,7 +43,32 @@ const setAttendance = async ({ contact_id, is_being_attended }) => {
   }
 };
 
+// Migrado do webhook N8n /responsability na Fase 4. Define quem está
+// "no comando" da conversa: 'latta' (bot), 'petshop' (operador humano)
+// ou outro path custom. Usado pelo dropdown "Trocar responsável" no
+// painel de mensageria.
+const setResponsibility = async ({ contact_id, user_id, path }) => {
+  try {
+    const contact = await Contact.findByPk(contact_id);
+    if (!contact) {
+      throw new Error('Contact not found');
+    }
+    contact.path = path || null;
+    contact.user_id = user_id || null;
+    await contact.save();
+    return {
+      id: contact.id,
+      cellphone: contact.cellphone,
+      path: contact.path,
+      user_id: contact.user_id,
+    };
+  } catch (error) {
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 export default {
   toggleAttendance,
   setAttendance,
+  setResponsibility,
 };

--- a/src/api/repositories/tag.repository.js
+++ b/src/api/repositories/tag.repository.js
@@ -1,4 +1,4 @@
-import { PetOwnerTag } from '../models/index.js';
+import { PetOwnerTag, PetOwnerTagAssignment } from '../models/index.js';
 
 const getAllTags = async ({ clinic_id, page = 1, limit = 15 }) => {
   try {
@@ -122,6 +122,30 @@ const searchTags = async ({ clinic_id, name, page = 1, limit = 15 }) => {
   }
 };
 
+// Migrado do webhook N8n /tags na Fase 4. Aplica create + delete em batch
+// na tabela M:M pet_owner_tag_assignments. Idempotente: re-create da mesma
+// associação não duplica (constraint UNIQUE), e delete inexistente é no-op.
+const manageAssignments = async ({ pet_owner_id, create = [], delete: toDelete = [] }) => {
+  try {
+    // Create — usa bulkCreate com ignoreDuplicates pra ser idempotente
+    if (Array.isArray(create) && create.length > 0) {
+      const rows = create.map((tag_id) => ({ pet_owner_id, tag_id }));
+      await PetOwnerTagAssignment.bulkCreate(rows, { ignoreDuplicates: true });
+    }
+
+    // Delete — destroy WHERE pet_owner_id = X AND tag_id IN (...)
+    if (Array.isArray(toDelete) && toDelete.length > 0) {
+      await PetOwnerTagAssignment.destroy({
+        where: { pet_owner_id, tag_id: toDelete },
+      });
+    }
+
+    return { created: create.length, deleted: toDelete.length };
+  } catch (error) {
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 export default {
   getAllTags,
   getTagById,
@@ -129,4 +153,5 @@ export default {
   updateTag,
   deleteTag,
   searchTags,
+  manageAssignments,
 };

--- a/src/api/routes/private/ai-feedback.routes.js
+++ b/src/api/routes/private/ai-feedback.routes.js
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import AIFeedbackController from '../../controllers/ai-feedback.controller.js';
+import { verifyToken, checkRole } from '../../middlewares/auth.middleware.js';
+
+const router = Router();
+
+// Migrado do webhook N8n /thumbs na Fase 4 (2026-05). Operador clica
+// 👍/👎 numa sugestão IA Offer/Scheduling no painel — UPDATE no registro
+// mais recente da tabela ai_agent_output.
+router.post(
+  '/thumbs',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  AIFeedbackController.setThumbs,
+);
+
+export default router;

--- a/src/api/routes/private/contact.routes.js
+++ b/src/api/routes/private/contact.routes.js
@@ -21,4 +21,14 @@ router.patch(
   ContactController.setAttendance,
 );
 
+// Migrado do webhook N8n /responsability na Fase 4 (2026-05). Define
+// quem está no comando da conversa: latta (bot), petshop (humano), ou
+// custom. Body: { user_id, path }.
+router.patch(
+  '/:id/responsibility',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ContactController.setResponsibility,
+);
+
 export default router;

--- a/src/api/routes/private/messaging.routes.js
+++ b/src/api/routes/private/messaging.routes.js
@@ -20,4 +20,14 @@ router.post(
   MessagingController.sendTemplate,
 );
 
+// Migrado do webhook N8n /ai_accepted na Fase 4 (2026-05). Operador
+// aprova/edita sugestão IA Offer ou Scheduling no painel e dispara
+// envio. Body: { contact_id, message, is_modificated? }.
+router.post(
+  '/send-ai-suggestion',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  MessagingController.sendAISuggestion,
+);
+
 export default router;

--- a/src/api/routes/private/tags.routes.js
+++ b/src/api/routes/private/tags.routes.js
@@ -31,4 +31,13 @@ router.put('/:id', verifyToken, checkRole(['admin', 'superAdmin']), TagControlle
 
 router.delete('/:id', verifyToken, checkRole(['admin', 'superAdmin']), TagController.deleteTag);
 
+// Migrado do webhook N8n /tags na Fase 4 (2026-05). Aplica create/delete
+// em batch nas associações pet_owner_tag_assignments.
+router.post(
+  '/manage-assignments',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  TagController.manageAssignments,
+);
+
 export default router;

--- a/src/api/routes/privateRoutes.js
+++ b/src/api/routes/privateRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import express from 'express';
 import AuthRoutes from './private/auth.routes.js';
+import AIFeedbackRoutes from './private/ai-feedback.routes.js';
 import ChatHistoryRoutes from './private/chat-history.routes.js';
 import ContactRoutes from './private/contact.routes.js';
 import MessagingRoutes from './private/messaging.routes.js';
@@ -21,6 +22,7 @@ import VarejonlineRoutes from './private/varejonline.routes.js';
 const router = Router();
 
 router.use('/auth', AuthRoutes);
+router.use('/ai/feedback', AIFeedbackRoutes);
 router.use('/chat-history', ChatHistoryRoutes);
 router.use('/contacts', ContactRoutes);
 router.use('/messaging', MessagingRoutes);

--- a/src/api/services/ai-feedback.service.js
+++ b/src/api/services/ai-feedback.service.js
@@ -1,0 +1,43 @@
+// AI Feedback service — substitui webhook N8n /thumbs (Fase 4).
+//
+// O painel mostra sugestões IA (offer/scheduling) com botões 👍/👎.
+// Operador clica e dispara feedback via este endpoint, que faz UPDATE
+// na ai_agent_output.thumbs do registro mais recente daquele cellphone.
+//
+// Não há model Sequelize pra ai_agent_output — a tabela é gerenciada
+// pelo workflow N8n IA. Usamos query SQL direto via sequelize.query.
+
+import { sequelize } from '../../config/database.js';
+
+const setThumbs = async ({ cell_phone, thumbs }) => {
+  if (!cell_phone) throw new Error('cell_phone is required');
+  if (thumbs !== 'up' && thumbs !== 'down') {
+    throw new Error('thumbs must be up or down');
+  }
+
+  // UPDATE no registro MAIS RECENTE daquele cellphone (ORDER BY id DESC LIMIT 1
+  // via subquery — Postgres permite UPDATE com WHERE id IN (subselect)).
+  const [_, meta] = await sequelize.query(
+    `UPDATE ai_agent_output
+     SET thumbs = :thumbs
+     WHERE id = (
+       SELECT id FROM ai_agent_output
+       WHERE cellphone = :cell_phone
+       ORDER BY created_at DESC
+       LIMIT 1
+     )
+     RETURNING id, cellphone, thumbs`,
+    {
+      replacements: { thumbs, cell_phone },
+    },
+  );
+
+  return {
+    success: true,
+    rows_updated: meta?.rowCount ?? 0,
+  };
+};
+
+export default {
+  setThumbs,
+};

--- a/src/api/services/contact.service.js
+++ b/src/api/services/contact.service.js
@@ -18,7 +18,16 @@ const setAttendance = async ({ contact_id, is_being_attended }) => {
   }
 };
 
+const setResponsibility = async ({ contact_id, user_id, path }) => {
+  try {
+    return await ContactRepository.setResponsibility({ contact_id, user_id, path });
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
 export default {
   toggleAttendance,
   setAttendance,
+  setResponsibility,
 };

--- a/src/api/services/messaging.service.js
+++ b/src/api/services/messaging.service.js
@@ -235,7 +235,56 @@ const sendTemplate = async ({ contact_id, template_id, manual_vars, user_id }) =
   return { success: true, message_id: messageId, template_name: template.template_name };
 };
 
+// Migrado do webhook N8n /ai_accepted na Fase 4. Operador aprova (👍) +
+// edita (opcional) a sugestão IA do painel; este endpoint manda a mensagem
+// final pro tutor e registra no chat_history com flags ai_accepted=true e
+// is_modified (true se operador editou o texto antes de enviar).
+const sendAISuggestion = async ({ contact_id, message, is_modificated, user_id }) => {
+  if (!contact_id) throw new Error('contact_id obrigatorio');
+  if (!message) throw new Error('message obrigatoria');
+
+  const contact = await Contact.findByPk(contact_id);
+  if (!contact) throw new Error('Contact nao encontrado');
+
+  const phone = contact.cellphone;
+  // Mesmo header *Luma*\n usado pelo sendText (UX consistente — tutor não
+  // vê diferença entre "sugestão IA aceita" e "texto livre" do painel).
+  const fullText = `*${LUMA_NAME}*\n${message}`;
+
+  const metaResp = await callMeta({
+    messaging_product: 'whatsapp',
+    recipient_type: 'individual',
+    to: phone,
+    type: 'text',
+    text: { body: fullText, preview_url: false },
+  });
+  const messageId = metaResp?.messages?.[0]?.id;
+
+  await logToHistory({
+    name: LUMA_NAME,
+    cell_phone: phone,
+    journey: 'enviada',
+    message,
+    sent_by: 'petshop',
+    message_type: 'text',
+    message_id: messageId,
+    path: 'petshop',
+    user_id: user_id || null,
+    contact_id,
+    pet_owner_id: contact.pet_owner_id || undefined,
+    clinic_id: contact.clinic_id || undefined,
+    ai_output: message,
+    is_modified: !!is_modificated,
+  });
+
+  // Luma assumiu via sugestão IA — set is_being_attended=true
+  await ContactRepository.setAttendance({ contact_id, is_being_attended: true });
+
+  return { success: true, message_id: messageId };
+};
+
 export default {
   sendText,
   sendTemplate,
+  sendAISuggestion,
 };

--- a/src/api/services/tag.service.js
+++ b/src/api/services/tag.service.js
@@ -118,6 +118,19 @@ const searchTags = async ({ clinic_id, query, page = 1, limit = 15 }) => {
   }
 };
 
+const manageAssignments = async ({ pet_owner_id, create, delete: toDelete }) => {
+  try {
+    if (!pet_owner_id) throw new Error('pet_owner_id is required');
+    return await TagRepository.manageAssignments({
+      pet_owner_id,
+      create: create || [],
+      delete: toDelete || [],
+    });
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
 export default {
   getAllTags,
   getTagById,
@@ -125,4 +138,5 @@ export default {
   updateTag,
   deleteTag,
   searchTags,
+  manageAssignments,
 };


### PR DESCRIPTION
## Summary

Migra 4 webhooks N8n pra endpoints Express autenticados. Frontend para de chamar `webhook.latta.app/...` pros 4 fluxos abaixo.

## Endpoints novos

| Endpoint | Substitui | Body |
|---|---|---|
| `POST /tags/manage-assignments` | `/tags` | `{ pet_owner_id, create: [tag_id...], delete: [tag_id...] }` |
| `PATCH /contacts/:id/responsibility` | `/responsability` | `{ user_id, path }` |
| `POST /ai/feedback/thumbs` | `/thumbs` | `{ cell_phone, thumbs: 'up'\|'down' }` |
| `POST /messaging/send-ai-suggestion` | `/ai_accepted` | `{ contact_id, message, is_modificated? }` |

Auth: `verifyToken` + `checkRole(['admin','superAdmin','attendant'])`.

## Implementação

- **Tags**: `tag.repository.manageAssignments` usa `bulkCreate({ ignoreDuplicates })` + `destroy({ where: { tag_id: [...] } })` — idempotente
- **Responsibility**: simples UPDATE em `contacts.path` e `contacts.user_id`. Cache Redis do workflow N8n original ficou de fora (invalidação por TTL)
- **Thumbs**: `sequelize.query` direto (sem model `ai_agent_output` no Sequelize) — UPDATE no registro mais recente daquele cellphone via `id = (SELECT id FROM ai_agent_output WHERE cellphone = X ORDER BY created_at DESC LIMIT 1)`
- **AI Suggestion**: similar ao `sendText` mas grava `ai_output` + `is_modified` no chat_history pra rastreio

## Pareado com

- **Frontend PR `Latta-app/frontend#feat/messaging-luma-fase4-frontend`**

**IMPORTANTE**: mergear backend ANTES do frontend.

## Pendente (Fase 5)

- `/agent_activated` (IA Offer LangChain + OpenAI + Varejo Online)
- `/scheduling` (IA Scheduling + Google Calendar)

Esses precisam refatoração + chat-engine EF (LangChain prompts) + integração externa OAuth — escopo separado.

## Test plan

- [ ] `POST /tags/manage-assignments { pet_owner_id, create: [uuid], delete: [] }` → 200, row em `pet_owner_tag_assignments`
- [ ] `PATCH /contacts/:id/responsibility { user_id, path: 'petshop' }` → 200, contact.path/user_id atualizados
- [ ] `POST /ai/feedback/thumbs { cell_phone, thumbs: 'up' }` → 200, ai_agent_output.thumbs atualizado
- [ ] `POST /messaging/send-ai-suggestion { contact_id, message, is_modificated: true }` → 200, tutor recebe `*Luma*\n{message}`, chat_history tem ai_output + is_modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)