### PR TITLE
fix(messaging): sendTemplate quebrava com pet_photo_commented missing

### DIFF
--- a/src/api/services/messaging.service.js
+++ b/src/api/services/messaging.service.js
@@ -90,10 +90,17 @@ async function buildTemplatePayload({ phone, template, manualVars, contact }) {
   let petOwner = null;
   let pet = null;
   if (contact?.pet_owner_id) {
-    petOwner = await PetOwner.findByPk(contact.pet_owner_id);
+    // attributes: ['id','name'] — sem isso o Sequelize tenta SELECT *
+    // (incluindo pet_photo_commented que existe no model mas nao no DB →
+    // erro 42703 quebra o envio de template). Pra resolver auto-vars
+    // só precisamos do nome do tutor.
+    petOwner = await PetOwner.findByPk(contact.pet_owner_id, {
+      attributes: ['id', 'name'],
+    });
     if (petOwner) {
       pet = await Pet.findOne({
         where: { pet_owner_id: petOwner.id },
+        attributes: ['id', 'name'],
         order: [['created_at', 'ASC']],
       });
     }


### PR DESCRIPTION
## Bug

Template selecionado no TemplateModal não era enviado — botão "enviar" disparava mas o tutor nunca recebia.

Logs do prod mostraram:
\`\`\`
error: column \"pet_photo_commented\" does not exist
sql: SELECT \"id\", \"clinic_id\", \"name\", ..., \"pet_photo_commented\", ... FROM \"pet_owners\" ...
\`\`\`

## Causa

`PetOwner.findByPk(id)` (no `messaging.service.buildTemplatePayload`) faz `SELECT *` por padrão. O model Sequelize tem `pet_photo_commented`, mas a tabela em prod **não** tem essa coluna — Postgres erro 42703.

`sendText` não era afetado (não chama `findByPk`).

## Fix

Passar `attributes: ['id', 'name']` em `findByPk` + `Pet.findOne`. Pra resolver `Primeiro Nome` / `Nome do Pet` só precisamos do `name`.

Solução alternativa seria corrigir o model `PetOwners` (remover `pet_photo_commented`), mas pode quebrar outros services que dependem do campo. `attributes` específico é mais cirúrgico e isolado.

## Pareado com

- Latta principal PR (em paralelo): bypass humano no workflow `Lattinha [Flows Journey]` pra fechar o caminho de onboarding (bug 2 reportado pelo user — Lattinha continuava respondendo após Luma assumir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)