### PR TITLE
fix(socket): user normal joina debug_global pra leads sem clinic

### DIFF
--- a/src/config/socket.js
+++ b/src/config/socket.js
@@ -148,6 +148,15 @@ function initializeSocket(httpServer) {
       socket.join(`clinic_${clinicId}`);
       console.log(`✅ Usuário adicionado à sala 'clinic_${clinicId}'`);
       console.log(`📊 Conexões ativas na clínica ${clinicId}: ${clinicUsers.size}`);
+
+      // Tambem entra em debug_global pra capturar mensagens de contacts SEM
+      // clinic_id (leads novos, conversas onde o user nunca foi vinculado a
+      // uma clinic). socketRoutes.js:155-157 emite essas mensagens APENAS
+      // pra debug_global — sem esse join, o operador so via depois de F5.
+      // Trade-off: se houver multi-clinic, esse user vera leads de outras
+      // clinics. Hoje so existe Suporte Latta como clinic real, entao OK.
+      socket.join('debug_global');
+      console.log(`✅ Usuário adicionado à sala 'debug_global' (catch-all leads sem clinic)`);
       console.log(`📊 Salas do socket:`, Array.from(socket.rooms));
 
       // Notificar outros atendentes


### PR DESCRIPTION
## Bug

User reportou: \"Íris mandou 'oi' no WhatsApp e a conversa não apareceu na mensageria.\"

Logs do backend confirmaram emit `new_message` com sucesso. Mas mensagem não chegou no painel em real-time.

## Diagnóstico

- **Iris (lead novo)** tem `clinic_id = null` em `pet_owner_clinics`
- [`socketRoutes.js:155-157`](src/api/routes/socket/socketRoutes.js#L155-L157) emite **só pra `debug_global`** quando msg sem `clinic_id`
- [`socket.js:148`](src/config/socket.js#L148) (user normal) só faz `socket.join('clinic_X')`
- [`socket.js:97`](src/config/socket.js#L97) (debugger) só faz `socket.join('debug_global')`
- → User normal **nunca** recebe msg sem `clinic_id` em real-time

## Fix

User normal também entra em `debug_global` após o join `clinic_<id>`. Catch-all pra leads novos.

**Trade-off**: se um dia houver multi-clinic, esse user vê leads de outras clinics. Hoje só existe Suporte Latta como clinic real, então sem leak. Quando escalar, criar sala dedicada (`leads_unassigned`) e só usuários autorizados entram.

## Pareado com

- **Frontend PR** — dropdown Responsabilidade mostra só Latta + Luma (esconde Suporte Latta/2)

## Test plan

- [ ] Restart backend EC2
- [ ] User normal logado no painel
- [ ] Tutor sem `clinic_id` (lead novo) manda msg → conversa aparece em real-time, sem F5
- [ ] Console do socket mostra `Salas do socket: [..., 'debug_global', 'clinic_<id>']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)