### PR TITLE
feat(messaging): exclui is_being_attended=true da aba Geral (pareado com aba Luma)

### DIFF
--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -142,6 +142,13 @@ const getAllContactsWithMessages = async ({
       },
     };
 
+    // Geral exclui conversas em atendimento humano (Luma assumiu) — essas
+    // só aparecem na aba "Luma" (getAllContactsBeingAttended). Sem isso,
+    // conversa atendida apareceria em duas abas. Aplicado só quando
+    // testFilter !== 'only' pra não interferir na aba Testes.
+    if (testFilter !== 'only') {
+      whereConditions.is_being_attended = { [Op.not]: true };
+    }
 
     // Constrói os filtros condicionalmente
     const additionalConditions = [];


### PR DESCRIPTION
## Summary

Pareado com frontend PR que adiciona aba **Luma** no painel. Sem este filtro, conversas em atendimento humano apareceriam em DUAS abas simultaneamente (Geral + Luma).

## Mudança

`getAllContactsWithMessages` agora aplica:

\`\`\`js
if (testFilter !== 'only') {
  whereConditions.is_being_attended = { [Op.not]: true };
}
\`\`\`

`Op.not: true` pega tanto `false` quanto `null` — qualquer estado que não seja "atendendo".

## Test plan

- [ ] Aba Geral: conversa com `is_being_attended=true` NÃO aparece
- [ ] Aba Luma (`in-attendance`): conversa com `is_being_attended=true` aparece
- [ ] Aba Testes (test personas): comportamento inalterado, é como filtro paralelo

🤖 Generated with [Claude Code](https://claude.com/claude-code)