### PR TITLE
feat(messaging): endpoint count pra badge da aba Luma

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -469,6 +469,23 @@ const getTestContactsCount = async (req, res) => {
   }
 };
 
+const getInAttendanceContactsCount = async (req, res) => {
+  try {
+    const { clinic_id } = req.user;
+    const result = await ChatService.getInAttendanceContactsCount({ clinic_id });
+    return res.status(200).json({
+      code: 'IN_ATTENDANCE_CONTACTS_COUNT_RETRIEVED',
+      data: { count: result.count },
+    });
+  } catch (error) {
+    console.error('Error retrieving in-attendance contacts count:', error);
+    return res.status(500).json({
+      code: 'IN_ATTENDANCE_CONTACTS_COUNT_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 // POST /chat-history/messages/markAsAnswered { cell_phone, pet_owner_id }
 // Migrado do webhook N8n is_answered (workflow Lattinha - Webhooks Front).
 // Aceita cell_phone OU pet_owner_id — pelo menos um deve vir. cell_phone
@@ -544,6 +561,7 @@ export default {
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getTestContactsCount,
+  getInAttendanceContactsCount,
   markAsAnswered,
   getMessagesDaysSummary,
 };

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -2092,6 +2092,33 @@ const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 20 }) => 
   }
 };
 
+// Conta contacts com is_being_attended=true (alimenta o badge da aba Luma).
+// Pareado com getAllContactsBeingAttended pra alinhar count vs lista. LEFT JOIN
+// em pet_owner_clinics pra incluir leads sem clinic vinculada (mesmo pattern
+// de getTestContactsCount).
+const getInAttendanceContactsCount = async ({ clinic_id }) => {
+  try {
+    const [result] = await Contact.sequelize.query(
+      `
+      SELECT COUNT(DISTINCT c.id)::int AS count
+      FROM contacts c
+      LEFT JOIN pet_owners po ON c.pet_owner_id = po.id
+      LEFT JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
+      WHERE (poc.clinic_id = :clinic_id OR poc.clinic_id IS NULL)
+      AND c.is_being_attended = true
+      `,
+      {
+        replacements: { clinic_id },
+        type: Sequelize.QueryTypes.SELECT,
+      },
+    );
+    return { count: result?.count || 0 };
+  } catch (error) {
+    console.error('❌ ERRO getInAttendanceContactsCount:', error.message);
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 const getTestContactsCount = async ({ clinic_id, role }) => {
   try {
     const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
@@ -2202,5 +2229,6 @@ export default {
   getAllContactsMessagesWithNoFilters,
   getOrdersByContactId,
   getTestContactsCount,
+  getInAttendanceContactsCount,
   getMessagesDaysSummary,
 };

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -32,6 +32,14 @@ router.get(
   ChatController.getTestContactsCount,
 );
 
+// Badge da aba "Luma" no painel — conta contacts.is_being_attended=true.
+router.get(
+  '/messages/getInAttendanceContactsCount',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getInAttendanceContactsCount,
+);
+
 router.get(
   '/messages/searchContacts',
   verifyToken,

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -112,6 +112,14 @@ const getTestContactsCount = async ({ clinic_id, role }) => {
   }
 };
 
+const getInAttendanceContactsCount = async ({ clinic_id }) => {
+  try {
+    return await ChatRepository.getInAttendanceContactsCount({ clinic_id });
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
 const getAllContactsBeingAttended = async ({
   clinic_id,
   role,
@@ -367,6 +375,7 @@ export default {
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getTestContactsCount,
+  getInAttendanceContactsCount,
   markAsAnswered,
   getMessagesDaysSummary,
 };


### PR DESCRIPTION
GET /chat-history/messages/getInAttendanceContactsCount → conta contacts.is_being_attended=true. Pareado com frontend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)