### PR TITLE
feat(templates): mostra PENDING/REJECTED de luma_custom_* + endpoint sync

### DIFF
--- a/src/api/controllers/template-create.controller.js
+++ b/src/api/controllers/template-create.controller.js
@@ -57,4 +57,20 @@ const submit = async (req, res) => {
   }
 };
 
-export default { draft, submit };
+const sync = async (req, res) => {
+  try {
+    const result = await TemplateCreateService.syncPendingTemplates();
+    return res.status(200).json({
+      code: 'TEMPLATES_SYNCED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('[template-create] sync falhou:', error.message);
+    return res.status(500).json({
+      code: 'TEMPLATE_SYNC_ERROR',
+      message: error.message,
+    });
+  }
+};
+
+export default { draft, submit, sync };

--- a/src/api/repositories/template.repository.js
+++ b/src/api/repositories/template.repository.js
@@ -7,18 +7,26 @@ const getAllTemplates = async ({ page = 1, limit = 15 }) => {
 
     const { count: totalItems, rows: templates } = await Template.findAndCountAll({
       where: {
-        // Esconde templates ARCHIVED (Petland-herdados desativados em 2026-05),
-        // PENDING (em revisão Meta — não pode enviar) e REJECTED.
-        template_status: 'APPROVED',
+        // APPROVED sempre visível. PENDING/REJECTED só pra templates criados
+        // pelo painel (luma_custom_*) — assim o operador acompanha o status
+        // do que ele mesmo solicitou (com badge "Solicitado" no frontend).
+        // ARCHIVED segue oculto.
+        [Op.and]: [
+          {
+            [Op.or]: [
+              { template_status: 'APPROVED' },
+              {
+                template_status: { [Op.in]: ['PENDING', 'REJECTED'] },
+                template_name: { [Op.like]: 'luma_custom_%' },
+              },
+            ],
+          },
+        ],
         // Esconde templates sem label legível ("Template sem nome" no painel).
-        // template_label é populado automaticamente pelo manage-templates.ts
-        // cmdCreate desde a Fase de melhorias 2026-05; templates antigos sem
-        // label só serão visíveis quando alguém preencher manualmente via SQL.
         template_label: { [Op.not]: null },
         // Mostra apenas templates assinados pela Luma (atendimento humano).
         // Templates da marca (*Latta 🐾*) são automatizados via cron/webhooks
         // e não fazem sentido como sugestão proativa pelo operador no painel.
-        // Critério via prefixo do body — robusto contra renaming de template.
         template_preview: { [Op.like]: '*Luma%' },
       },
       attributes: [

--- a/src/api/routes/private/template-create.routes.js
+++ b/src/api/routes/private/template-create.routes.js
@@ -23,4 +23,14 @@ router.post(
   TemplateCreateController.submit,
 );
 
+// Sincroniza status (PENDING → APPROVED/REJECTED) dos templates criados
+// pelo painel (luma_custom_*) consultando Meta API. Frontend chama ao
+// abrir o modal pra ver aprovacoes recentes sem esperar webhook.
+router.post(
+  '/sync',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  TemplateCreateController.sync,
+);
+
 export default router;

--- a/src/api/services/template-create.service.js
+++ b/src/api/services/template-create.service.js
@@ -12,6 +12,7 @@
 //      templateManualVars.js.
 
 import axios from 'axios';
+import { QueryTypes } from 'sequelize';
 import { Template } from '../models/index.js';
 import { sequelize } from '../../config/database.js';
 
@@ -360,7 +361,64 @@ const submitToMeta = async ({
   };
 };
 
+// Sincroniza status dos templates luma_custom_* PENDING/REJECTED com a Meta
+// API. Frontend chama isso ao abrir o modal pra refletir aprovacoes recentes
+// sem esperar webhook Meta. Limita a templates do painel pra nao bater Meta
+// API toa pros legados que nao mudam.
+const syncPendingTemplates = async () => {
+  if (!META_TOKEN) {
+    return { synced: 0, skipped: 0, reason: 'no_meta_token' };
+  }
+
+  const pending = await sequelize.query(
+    `SELECT id, template_code, template_name, template_status
+     FROM templates
+     WHERE template_name LIKE 'luma_custom_%'
+       AND template_status IN ('PENDING', 'REJECTED')
+       AND template_code IS NOT NULL`,
+    { type: QueryTypes.SELECT },
+  );
+
+  if (pending.length === 0) {
+    return { synced: 0, skipped: 0 };
+  }
+
+  let synced = 0;
+  let skipped = 0;
+  for (const tpl of pending) {
+    try {
+      // GET /{template_id} retorna { name, status, language, components, ... }
+      const resp = await axios.get(
+        `${WHATSAPP_API}/${tpl.template_code}`,
+        {
+          headers: { Authorization: `Bearer ${META_TOKEN}` },
+          timeout: 10000,
+        },
+      );
+      const newStatus = resp.data?.status;
+      if (newStatus && newStatus !== tpl.template_status) {
+        await sequelize.query(
+          `UPDATE templates SET template_status = :status, updated_at = NOW()
+           WHERE id = :id`,
+          {
+            replacements: { status: newStatus, id: tpl.id },
+          },
+        );
+        synced++;
+      } else {
+        skipped++;
+      }
+    } catch (err) {
+      console.warn(`[template-sync] ${tpl.template_name} falhou:`, err.message);
+      skipped++;
+    }
+  }
+
+  return { synced, skipped, total: pending.length };
+};
+
 export default {
   draftFromDescription,
   submitToMeta,
+  syncPendingTemplates,
 };


### PR DESCRIPTION
Templates criados via painel agora aparecem na lista com status real (Solicitado/Rejeitado). POST /sync atualiza status via Meta API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)