### PR TITLE
refactor(messaging): unifica visao do painel (remove clinic_id filter)

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -4,7 +4,7 @@ const getAllContactsWithMessages = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
-    const { id, role, clinic_id } = req.user;
+    const { id, role } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -18,7 +18,6 @@ const getAllContactsWithMessages = async (req, res) => {
 
     const result = await ChatService.getAllContactsWithMessages({
       user_id: id,
-      clinic_id,
       role: role.role,
       page,
       limit,
@@ -42,7 +41,7 @@ const getAllContactsBeingAttended = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
-    const { id, role, clinic_id } = req.user;
+    const { id, role } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -56,7 +55,6 @@ const getAllContactsBeingAttended = async (req, res) => {
 
     const result = await ChatService.getAllContactsBeingAttended({
       user_id: id,
-      clinic_id,
       role: role.role,
       page,
       limit,
@@ -79,7 +77,7 @@ const getAllContactsBeingAttended = async (req, res) => {
 const searchContacts = async (req, res) => {
   try {
     const { query, page = 1, limit = 15 } = req.query;
-    const { id, clinic_id, role } = req.user;
+    const { id, role } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -92,13 +90,12 @@ const searchContacts = async (req, res) => {
     };
 
     const contacts = await ChatService.searchContacts({
-      clinic_id,
       query,
       page: parseInt(page),
       limit: parseInt(limit),
       role: role.role,
       user_id: id,
-      filters, // Novo parâmetro
+      filters,
     });
 
     return res.status(200).json({
@@ -307,51 +304,6 @@ const getOrdersByContactId = async (req, res) => {
   }
 };
 
-const getAllContactsMessagesWithNoFilters = async (req, res) => {
-  try {
-    const { role } = req.user;
-    const { page = 1, limit = 15 } = req.query; // Mudei de 20 para 15 para manter padrão
-
-    const pageNum = parseInt(page);
-    const limitNum = parseInt(limit);
-
-    if (pageNum < 1 || limitNum < 1 || limitNum > 100) {
-      return res.status(400).json({
-        code: 'INVALID_PAGINATION_PARAMS',
-        message: 'Invalid pagination parameters',
-      });
-    }
-
-    console.log('🔍 Controller - Buscando TODOS os contatos sem filtros');
-
-    const result = await ChatService.getAllContactsMessagesWithNoFilters({
-      role: role.role,
-      page: pageNum,
-      limit: limitNum,
-    });
-
-    // Corrigir estrutura da resposta - deve retornar contacts, não contact
-    if (!result || !result.contacts) {
-      return res.status(404).json({
-        code: 'CONTACTS_NOT_FOUND',
-        message: 'No contacts found',
-      });
-    }
-
-    return res.status(200).json({
-      code: 'CONTACTS_RETRIEVED',
-      data: result.contacts,
-      totalItems: result.totalItems,
-    });
-  } catch (error) {
-    console.error('Error retrieving all contacts without filters:', error);
-    return res.status(500).json({
-      code: 'CONTACTS_RETRIEVAL_ERROR',
-      message: error.message,
-    });
-  }
-};
-
 const getContactByPetOwnerIdOrPhone = async (req, res) => {
   try {
     const { pet_owner_id, contact } = req.query;
@@ -417,7 +369,7 @@ const getAllTestContacts = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 15;
-    const { id, role, clinic_id } = req.user;
+    const { id, role } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -427,7 +379,6 @@ const getAllTestContacts = async (req, res) => {
 
     const result = await ChatService.getAllTestContacts({
       user_id: id,
-      clinic_id,
       role: role.role,
       page,
       limit,
@@ -449,10 +400,9 @@ const getAllTestContacts = async (req, res) => {
 
 const getTestContactsCount = async (req, res) => {
   try {
-    const { role, clinic_id } = req.user;
+    const { role } = req.user;
 
     const result = await ChatService.getTestContactsCount({
-      clinic_id,
       role: role.role,
     });
 
@@ -469,10 +419,9 @@ const getTestContactsCount = async (req, res) => {
   }
 };
 
-const getInAttendanceContactsCount = async (req, res) => {
+const getInAttendanceContactsCount = async (_req, res) => {
   try {
-    const { clinic_id } = req.user;
-    const result = await ChatService.getInAttendanceContactsCount({ clinic_id });
+    const result = await ChatService.getInAttendanceContactsCount();
     return res.status(200).json({
       code: 'IN_ATTENDANCE_CONTACTS_COUNT_RETRIEVED',
       data: { count: result.count },
@@ -554,7 +503,6 @@ export default {
   getAllContactsWithMessages,
   getAllContactsBeingAttended,
   searchContacts,
-  getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerId,
   getContactByContactId,
   getOrdersByContactId,

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -85,7 +85,6 @@ const buildTestChatFilter = (testFilter = 'exclude') => {
 };
 
 const getAllContactsWithMessages = async ({
-  clinic_id,
   role,
   page = 1,
   limit = 15,
@@ -101,40 +100,18 @@ const getAllContactsWithMessages = async ({
     const chatHistoryWhere = shouldFilterLatta ? { path: { [Op.ne]: 'latta' } } : {};
     const testChatFilter = buildTestChatFilter(testFilter);
 
-    // Filtro base: contatos da clínica QUE TÊM pelo menos uma chat_history.
-    // O EXISTS substitui o antigo `required: true` no include de chatHistory,
-    // que não funciona junto com `separate: true` (necessário para o limit
-    // por contato funcionar corretamente).
-    //
-    // Quando testFilter === 'only' (aba Testes), usamos LEFT JOIN + OR IS NULL
-    // para alinhar com getTestContactsCount (linha ~1770): test personas criadas
-    // pelo script de testes NÃO têm row em pet_owner_clinics, então INNER JOIN
-    // as excluiria e a aba Testes ficaria vazia mesmo com count > 0. Bug real
-    // reportado em 2026-04-14 (count=14 mas lista []).
-    const baseSubquery = testFilter === 'only'
-      ? `(
-          SELECT DISTINCT c.id
-          FROM contacts c
-          LEFT JOIN pet_owners po ON c.pet_owner_id = po.id
-          LEFT JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-          WHERE (poc.clinic_id = '${clinic_id}' OR poc.clinic_id IS NULL)
-          AND EXISTS (
-            SELECT 1 FROM chat_history ch
-            WHERE ch.contact_id = c.id
-          )
-        )`
-      : `(
-          SELECT DISTINCT c.id
-          FROM contacts c
-          INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-          INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-          WHERE poc.clinic_id = '${clinic_id}'
-          AND EXISTS (
-            SELECT 1 FROM chat_history ch
-            WHERE ch.contact_id = c.id
-            ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
-          )
-        )`;
+    // Filtro base: contatos QUE TÊM pelo menos uma chat_history. Sem corte por
+    // clinic_id — visão unificada (refactor 2026-05-08): só dois sócios usam o
+    // painel, ambos veem tudo. Se voltar multi-clinic, reintroduzir join aqui.
+    const baseSubquery = `(
+      SELECT DISTINCT c.id
+      FROM contacts c
+      WHERE EXISTS (
+        SELECT 1 FROM chat_history ch
+        WHERE ch.contact_id = c.id
+        ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
+      )
+    )`;
 
     let whereConditions = {
       id: {
@@ -176,10 +153,8 @@ const getAllContactsWithMessages = async ({
             SELECT DISTINCT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-            INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
             INNER JOIN pet_owner_tag_assignments pota ON po.id = pota.pet_owner_id
             WHERE pota.tag_id IN (${escapedTags})
-            AND poc.clinic_id = '${clinic_id}'
           )`),
         },
       });
@@ -192,10 +167,7 @@ const getAllContactsWithMessages = async ({
           [Op.in]: Sequelize.literal(`(
             SELECT c.id
             FROM contacts c
-            INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-            INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-            WHERE poc.clinic_id = '${clinic_id}'
-            AND EXISTS (
+            WHERE EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
               ${shouldFilterLatta ? `AND ch1.path != 'latta'` : ''}
@@ -219,10 +191,7 @@ const getAllContactsWithMessages = async ({
           [Op.in]: Sequelize.literal(`(
             SELECT c.id
             FROM contacts c
-            INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-            INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-            WHERE poc.clinic_id = '${clinic_id}'
-            AND EXISTS (
+            WHERE EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
               ${shouldFilterLatta ? `AND ch1.path != 'latta'` : ''}
@@ -428,7 +397,6 @@ const getAllContactsWithMessages = async ({
 };
 
 const getAllContactsBeingAttended = async ({
-  clinic_id,
   role,
   page = 1,
   limit = 15,
@@ -444,19 +412,15 @@ const getAllContactsBeingAttended = async ({
     const chatHistoryWhere = shouldFilterLatta ? { path: { [Op.ne]: 'latta' } } : {};
     const testChatFilter = buildTestChatFilter(testFilter);
 
-    // Filtro base: contatos em atendimento na clínica QUE TÊM chat_history.
-    // O EXISTS substitui o antigo `required: true` no include de chatHistory,
-    // que não funciona com `separate: true` (necessário para o limit por contato).
+    // Filtro base: contatos em atendimento humano (Luma) com chat_history.
+    // Sem corte por clinic_id — visão unificada (refactor 2026-05-08).
     let whereConditions = {
       is_being_attended: true,
       id: {
         [Op.in]: Sequelize.literal(`(
           SELECT DISTINCT c.id
           FROM contacts c
-          INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-          INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-          WHERE poc.clinic_id = '${clinic_id}'
-          AND c.is_being_attended = true
+          WHERE c.is_being_attended = true
           AND EXISTS (
             SELECT 1 FROM chat_history ch
             WHERE ch.contact_id = c.id
@@ -490,10 +454,8 @@ const getAllContactsBeingAttended = async ({
             SELECT DISTINCT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-            INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
             INNER JOIN pet_owner_tag_assignments pota ON po.id = pota.pet_owner_id
             WHERE pota.tag_id IN (${escapedTags})
-            AND poc.clinic_id = '${clinic_id}'
             AND c.is_being_attended = true
           )`),
         },
@@ -507,10 +469,7 @@ const getAllContactsBeingAttended = async ({
           [Op.in]: Sequelize.literal(`(
             SELECT c.id
             FROM contacts c
-            INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-            INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-            WHERE poc.clinic_id = '${clinic_id}'
-            AND c.is_being_attended = true
+            WHERE c.is_being_attended = true
             AND EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
@@ -535,10 +494,7 @@ const getAllContactsBeingAttended = async ({
           [Op.in]: Sequelize.literal(`(
             SELECT c.id
             FROM contacts c
-            INNER JOIN pet_owners po ON c.pet_owner_id = po.id
-            INNER JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-            WHERE poc.clinic_id = '${clinic_id}'
-            AND c.is_being_attended = true
+            WHERE c.is_being_attended = true
             AND EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
@@ -735,7 +691,6 @@ const getAllContactsBeingAttended = async ({
 };
 
 const searchContacts = async ({
-  clinic_id,
   name,
   phone,
   page = 1,
@@ -782,10 +737,8 @@ const searchContacts = async ({
       finalConditions.push({ [Op.or]: nameConditions });
     }
 
-    let whereConditions = {
-      clinic_id,
-      ...(finalConditions.length > 0 ? { [Op.or]: finalConditions } : {}),
-    };
+    // Sem corte por clinic_id — visão unificada (refactor 2026-05-08).
+    let whereConditions = finalConditions.length > 0 ? { [Op.or]: finalConditions } : {};
 
     // Aplica os filtros adicionais (mesma lógica do getAllContacts)
     const additionalConditions = [];
@@ -796,12 +749,11 @@ const searchContacts = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT DISTINCT c.id 
+            SELECT DISTINCT c.id
             FROM contacts c
             INNER JOIN pet_owners po ON c.pet_owner_id = po.id
             INNER JOIN pet_owner_tag_assignments pota ON po.id = pota.pet_owner_id
             WHERE pota.tag_id IN (${escapedTags})
-            AND c.clinic_id = '${clinic_id}'
           )`),
         },
       });
@@ -812,10 +764,9 @@ const searchContacts = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT c.id 
+            SELECT c.id
             FROM contacts c
-            WHERE c.clinic_id = '${clinic_id}'
-            AND EXISTS (
+            WHERE EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
               ${shouldFilterLatta ? `AND ch1.path != 'latta'` : ''}
@@ -837,10 +788,9 @@ const searchContacts = async ({
       additionalConditions.push({
         id: {
           [Op.in]: Sequelize.literal(`(
-            SELECT c.id 
+            SELECT c.id
             FROM contacts c
-            WHERE c.clinic_id = '${clinic_id}'
-            AND EXISTS (
+            WHERE EXISTS (
               SELECT 1 FROM chat_history ch1
               WHERE ch1.contact_id = c.id
               ${shouldFilterLatta ? `AND ch1.path != 'latta'` : ''}
@@ -1835,280 +1785,18 @@ const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
   }
 };
 
-const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 20 }) => {
-  try {
-    const offset = (page - 1) * limit;
-    const { Op } = Sequelize;
-
-    // Exclui test personas mesmo no modo "sem filtros" — elas têm sua própria
-    // aba "Testes" no frontend e poluem a visualização quando misturadas aos
-    // contatos reais. Usa o marcador chat_history.path LIKE 'test-persona|%'
-    // (source of truth, gravado pela EF chat-history-logger).
-    const testPersonaExcludeWhere = {
-      id: {
-        [Op.notIn]: Sequelize.literal(TEST_CONTACT_IDS_SUBQUERY),
-      },
-    };
-
-    const { count: totalItems, rows: contacts } = await Contact.findAndCountAll({
-      where: testPersonaExcludeWhere,
-      limit,
-      offset,
-      distinct: true,
-      order: [
-        [
-          Sequelize.literal(`(
-            SELECT MAX(chat_history.timestamp)
-            FROM chat_history
-            WHERE chat_history.contact_id = "Contact".id
-          )`),
-          'DESC NULLS LAST',
-        ],
-        ['updated_at', 'DESC'],
-      ],
-      include: [
-        {
-          model: ChatHistory,
-          as: 'chatHistory',
-          // 🎯 SOLUÇÃO: Subquery para limitar a 15 mensagens mais recentes por contato
-          where: {
-            id: {
-              [Op.in]: Sequelize.literal(`(
-                SELECT ch.id 
-                FROM chat_history ch
-                WHERE ch.contact_id = "Contact".id
-                ORDER BY ch.timestamp DESC
-                LIMIT 15
-              )`),
-            },
-          },
-          attributes: [
-            'id',
-            [Sequelize.fn('LEFT', Sequelize.col('chatHistory.message'), 8000), 'message'],
-            'sent_by',
-            'sent_to',
-            'role',
-            'timestamp',
-            'window_timestamp',
-            'journey',
-            'message_type',
-            'date',
-            'message_id',
-            'midia_url',
-            'midia_name',
-            'reply',
-            'path',
-            'user_id',
-            'is_answered',
-            'template_id',
-            'n8n_execution_id',
-            'n8n_workflow_id',
-          ],
-          required: false, // false para incluir contatos sem mensagens também
-          order: [['timestamp', 'DESC']],
-          include: [
-            {
-              model: ChatHistoryContacts,
-              as: 'chatHistoryContacts',
-              attributes: [
-                'id',
-                'contact_name',
-                'cellphone',
-                'contact_phone',
-                'message_id',
-                'created_at',
-                'updated_at',
-              ],
-              required: false,
-            },
-            {
-              model: Template,
-              as: 'template',
-              attributes: [
-                'id',
-                'template_name',
-                'template_label',
-                'template_category',
-                'template_status',
-              ],
-              required: false,
-              include: [
-                {
-                  model: TemplateVariable,
-                  as: 'variables',
-                  attributes: [
-                    'id',
-                    'template_id',
-                    'template_component_id',
-                    'template_component_type_id',
-                    'template_varible_type_id',
-                    'variable_position',
-                  ],
-                  required: false,
-                  include: [
-                    {
-                      model: TemplateVariableType,
-                      as: 'templateVariableType',
-                      attributes: ['id', 'type', 'description', 'n8n_formula'],
-                      required: false,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          model: PetOwner,
-          as: 'petOwner',
-          attributes: [
-            'id',
-            'name',
-            'email',
-            'cell_phone',
-            'cpf',
-            'date_of_birth',
-            'is_active',
-            'created_at',
-          ],
-          required: false,
-          include: [
-            {
-              model: Pet,
-              as: 'pets',
-              attributes: ['id', 'name', 'date_of_birthday', 'photo', 'photo_thumb', 'pet_subscription_id'],
-              through: { attributes: [] },
-              where: { is_active: true },
-              required: false,
-              include: [
-                {
-                  model: PetType,
-                  as: 'type',
-                  attributes: ['id', 'name', 'label'],
-                  required: false,
-                },
-                {
-                  model: PetBreed,
-                  as: 'breed',
-                  attributes: ['id', 'name', 'label'],
-                  required: false,
-                },
-                {
-                  model: PetGender,
-                  as: 'gender',
-                  attributes: ['id', 'name', 'label'],
-                  required: false,
-                },
-                {
-                  model: PetSize,
-                  as: 'size',
-                  attributes: ['id', 'name', 'label'],
-                  required: false,
-                },
-                {
-                  model: PetFurLength,
-                  as: 'furLength',
-                  attributes: ['id', 'name', 'label'],
-                  required: false,
-                },
-                {
-                  model: PetSubscription,
-                  as: 'subscription',
-                  attributes: ['id', 'name'],
-                  required: false,
-                },
-              ],
-            },
-            {
-              model: PetOwnerTag,
-              as: 'tags',
-              attributes: ['id', 'name', 'label', 'color', 'is_active'],
-              through: {
-                attributes: ['assigned_at', 'user_id'],
-              },
-              where: { is_active: true },
-              required: false,
-            },
-            // Order include removido do listing — detalhe via
-            // getContactByPetOwnerId. Sem o ORDER BY name/ASC inline pq não
-            // é uma listing com tags.
-          ],
-        },
-      ],
-    });
-
-
-    // 📊 Debug detalhado das mensagens por contato
-    let totalMessages = 0;
-    contacts.forEach((contact, index) => {
-      const messageCount = contact.chatHistory ? contact.chatHistory.length : 0;
-      totalMessages += messageCount;
-      console.log(`📱 Contato ${index + 1} (ID: ${contact.id}): ${messageCount} mensagens`);
-
-      // Log do pet owner se existir
-      if (contact.petOwner) {
-        console.log(`   👤 Pet Owner: ${contact.petOwner.name} (${contact.petOwner.cell_phone})`);
-      }
-    });
-
-    console.log(
-      `📈 PERFORMANCE: ${totalMessages} mensagens carregadas no total (máximo ${limit * 15})`,
-    );
-    console.log(
-      `⚡ Economia: ${limit * 15 - totalMessages} mensagens não carregadas desnecessariamente`,
-    );
-
-    // 🔄 Ordenar as mensagens de cada contato por timestamp DESC (mais recente primeiro)
-    const processedContacts = contacts.map((contact) => {
-      if (contact.chatHistory && contact.chatHistory.length > 0) {
-        contact.chatHistory.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-      }
-      return contact;
-    });
-
-    return {
-      contacts: processedContacts,
-      totalItems,
-      metadata: {
-        page: parseInt(page),
-        limit: parseInt(limit),
-        offset,
-        totalPages: Math.ceil(totalItems / limit),
-        totalMessagesLoaded: totalMessages,
-        maxPossibleMessages: limit * 15,
-        hasNextPage: page * limit < totalItems,
-        hasPreviousPage: page > 1,
-      },
-    };
-  } catch (error) {
-    console.error('❌ ERRO NA FUNÇÃO getAllContactsMessagesWithNoFilters:', error.message);
-    console.error('❌ STACK TRACE:', error.stack);
-
-    // Log adicional para debug — offset pode não estar em escopo se o erro
-    // ocorreu antes da declaração `const offset = ...` dentro do try.
-    console.error('❌ PARÂMETROS:', { page, limit });
-
-    throw new Error(`Repository error: ${error.message}`);
-  }
-};
 
 // Conta contacts com is_being_attended=true (alimenta o badge da aba Luma).
-// Pareado com getAllContactsBeingAttended pra alinhar count vs lista. LEFT JOIN
-// em pet_owner_clinics pra incluir leads sem clinic vinculada (mesmo pattern
-// de getTestContactsCount).
-const getInAttendanceContactsCount = async ({ clinic_id }) => {
+// Sem corte por clinic_id — visão unificada (refactor 2026-05-08).
+const getInAttendanceContactsCount = async () => {
   try {
     const [result] = await Contact.sequelize.query(
       `
-      SELECT COUNT(DISTINCT c.id)::int AS count
+      SELECT COUNT(*)::int AS count
       FROM contacts c
-      LEFT JOIN pet_owners po ON c.pet_owner_id = po.id
-      LEFT JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-      WHERE (poc.clinic_id = :clinic_id OR poc.clinic_id IS NULL)
-      AND c.is_being_attended = true
+      WHERE c.is_being_attended = true
       `,
       {
-        replacements: { clinic_id },
         type: Sequelize.QueryTypes.SELECT,
       },
     );
@@ -2119,22 +1807,17 @@ const getInAttendanceContactsCount = async ({ clinic_id }) => {
   }
 };
 
-const getTestContactsCount = async ({ clinic_id, role }) => {
+const getTestContactsCount = async ({ role }) => {
   try {
     const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
 
     // Conta contatos com ao menos 1 chat marcado como test-persona pela EF
-    // chat-history-logger. LEFT JOIN em pet_owner_clinics pra também pegar
-    // test personas que não foram associadas a clinic (criadas direto pelo
-    // script sem passar pela seed de clinic).
+    // chat-history-logger. Sem corte por clinic_id — visão unificada.
     const [result] = await Contact.sequelize.query(
       `
       SELECT COUNT(DISTINCT c.id)::int AS count
       FROM contacts c
-      LEFT JOIN pet_owners po ON c.pet_owner_id = po.id
-      LEFT JOIN pet_owner_clinics poc ON po.id = poc.pet_owner_id
-      WHERE (poc.clinic_id = :clinic_id OR poc.clinic_id IS NULL)
-      AND EXISTS (
+      WHERE EXISTS (
         SELECT 1 FROM chat_history ch
         WHERE ch.contact_id = c.id
         AND ch.path LIKE 'test-persona|%'
@@ -2142,7 +1825,6 @@ const getTestContactsCount = async ({ clinic_id, role }) => {
       )
       `,
       {
-        replacements: { clinic_id },
         type: Sequelize.QueryTypes.SELECT,
       },
     );
@@ -2226,7 +1908,6 @@ export default {
   getContactByPetOwnerId,
   getContactByContactId,
   getContactByPetOwnerIdOrPhone,
-  getAllContactsMessagesWithNoFilters,
   getOrdersByContactId,
   getTestContactsCount,
   getInAttendanceContactsCount,

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -82,20 +82,6 @@ router.get(
   ChatController.getContactByPetOwnerId,
 );
 
-router.get(
-  '/messages/getAllContactsMessagesWithNoFilters',
-  verifyToken,
-  checkRole(['admin', 'superAdmin', 'attendant']),
-  ChatController.getAllContactsMessagesWithNoFilters,
-);
-
-router.get(
-  '/messages/loadMoreAllContacts',
-  verifyToken,
-  checkRole(['admin', 'superAdmin', 'attendant']),
-  ChatController.getAllContactsMessagesWithNoFilters,
-);
-
 // Marca mensagens não-respondidas de um pet_owner como answered (substitui
 // o webhook N8n `is_answered` em Lattinha - Webhooks Front).
 router.post(

--- a/src/api/routes/socket/socketRoutes.js
+++ b/src/api/routes/socket/socketRoutes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import S3ClientUtil from '../../../utils/s3.js';
 import ChatRepository from '../../repositories/chat-history.repository.js';
 import { isValidUUID } from '../../../utils/validate.js';
+import { MESSAGING_ROOM } from '../../../config/socket.js';
 
 // Função para assinar URLs de mídia
 const signMessageMediaUrl = async (messageData) => {
@@ -44,7 +45,7 @@ const attachReplyMessage = async (messageData) => {
   return messageData;
 };
 
-function createSocketRoutes(io, clinicConnections) {
+function createSocketRoutes(io) {
   const router = express.Router();
 
   // ==========================================
@@ -128,57 +129,22 @@ function createSocketRoutes(io, clinicConnections) {
       messageData = await signMessageMediaUrl(messageData);
       messageData = await attachReplyMessage(messageData);
 
-      // ======================
-      // 1️⃣ Log de conexões
-      // ======================
-      const allSockets = Array.from(io.sockets.sockets.values());
-      const debuggerSockets = allSockets.filter((s) => s.user?.email === 'debuger@latta.app');
-      console.log('🧠 TOTAL DE SOCKETS CONECTADOS:', allSockets.length);
+      // Visão unificada (refactor 2026-05-08): emite pra sala global única.
+      // Todos os usuários autenticados recebem todas as mensagens.
+      const room = io.sockets.adapter.rooms.get(MESSAGING_ROOM);
       console.log(
-        '🐞 DEBUGGERS ATIVOS:',
-        debuggerSockets.map((s) => ({
-          id: s.id,
-          email: s.user?.email,
-          salas: Array.from(s.rooms),
-        })),
+        room
+          ? `✅ Sala '${MESSAGING_ROOM}' com ${room.size} sockets`
+          : `❌ Sala '${MESSAGING_ROOM}' vazia`,
       );
 
-      // ======================
-      // 2️⃣ Emissão para a clínica
-      // ======================
-      if (clinic_id) {
-        const roomName = `clinic_${clinic_id}`;
-        const clinicAttendants = clinicConnections.get(clinic_id);
-        console.log(`📨 Enviando mensagem para sala: ${roomName}`);
-        console.log(`👥 Atendentes conectados nessa clínica: ${clinicAttendants?.size || 0}`);
+      io.to(MESSAGING_ROOM).emit('new_message', messageData);
+      console.log(`📤 new_message emitido para '${MESSAGING_ROOM}'`);
 
-        io.to(roomName).emit('new_message', messageData);
-      } else {
-        console.log('⚠️ Mensagem sem clinic_id — será enviada apenas para debug_global');
-      }
-
-      // ======================
-      // 3️⃣ Emissão global
-      // ======================
-      console.log(`🐛 Tentando enviar mensagem para sala 'debug_global'...`);
-      const debugRoom = io.sockets.adapter.rooms.get('debug_global');
-      console.log(
-        debugRoom
-          ? `✅ Sala 'debug_global' existe com ${debugRoom.size} sockets`
-          : '❌ Sala debug_global não existe ou vazia',
-      );
-
-      io.to('debug_global').emit('new_message', messageData);
-      console.log('📤 Evento new_message emitido para debug_global com sucesso');
-
-      // ======================
-      // 4️⃣ Retorno da API
-      // ======================
       res.json({
         success: true,
         sent: true,
-        clinic_id: clinic_id || null,
-        debug_notified: true,
+        room: MESSAGING_ROOM,
       });
 
       console.log('✅ Webhook finalizado com sucesso');
@@ -194,11 +160,9 @@ function createSocketRoutes(io, clinicConnections) {
   // ==========================================
   router.post('/test-socket', express.json(), async (_req, res) => {
     console.log('\n🧪 TESTE MANUAL DE SOCKET');
-    console.log('📡 Emitindo mensagens de teste para as salas...');
 
     const testMessage = {
       id: 'test-' + Date.now(),
-      clinic_id: '524f5b01-20b7-45e0-adf4-7b4eecea938a',
       contact_id: 'test-contact',
       message: 'MENSAGEM DE TESTE DO SOCKET',
       timestamp: new Date(),
@@ -207,26 +171,15 @@ function createSocketRoutes(io, clinicConnections) {
       role: 'client',
     };
 
-    // Log das salas antes de emitir
     const allRooms = Array.from(io.sockets.adapter.rooms.keys());
-    console.log('📡 Todas as salas atuais:', allRooms);
+    const room = io.sockets.adapter.rooms.get(MESSAGING_ROOM);
 
-    const debugRoom = io.sockets.adapter.rooms.get('debug_global');
-    console.log(
-      debugRoom
-        ? `✅ Sala debug_global com ${debugRoom.size} sockets`
-        : '❌ Sala debug_global inexistente',
-    );
-
-    io.to('clinic_524f5b01-20b7-45e0-adf4-7b4eecea938a').emit('new_message', testMessage);
-    io.to('debug_global').emit('new_message', testMessage);
-
-    console.log('✅ Mensagens de teste emitidas com sucesso');
+    io.to(MESSAGING_ROOM).emit('new_message', testMessage);
 
     res.json({
       success: true,
       rooms: allRooms,
-      debugRoomSize: debugRoom?.size || 0,
+      messagingRoomSize: room?.size || 0,
     });
   });
 

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -52,7 +52,6 @@ const attachReplyMessages = async (contacts) => {
 };
 
 const getAllContactsWithMessages = async ({
-  clinic_id,
   role,
   page = 1,
   limit = 15,
@@ -62,12 +61,11 @@ const getAllContactsWithMessages = async ({
 }) => {
   try {
     const result = await ChatRepository.getAllContactsWithMessages({
-      clinic_id,
       role,
       page,
       limit,
       user_id,
-      filters, // Repassa os filtros para o repository
+      filters,
       testFilter,
     });
     const contacts = result.contacts;
@@ -86,7 +84,6 @@ const getAllContactsWithMessages = async ({
 };
 
 const getAllTestContacts = async ({
-  clinic_id,
   role,
   page = 1,
   limit = 15,
@@ -94,7 +91,6 @@ const getAllTestContacts = async ({
   filters = {},
 }) => {
   return getAllContactsWithMessages({
-    clinic_id,
     role,
     page,
     limit,
@@ -104,24 +100,23 @@ const getAllTestContacts = async ({
   });
 };
 
-const getTestContactsCount = async ({ clinic_id, role }) => {
+const getTestContactsCount = async ({ role }) => {
   try {
-    return await ChatRepository.getTestContactsCount({ clinic_id, role });
+    return await ChatRepository.getTestContactsCount({ role });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
 };
 
-const getInAttendanceContactsCount = async ({ clinic_id }) => {
+const getInAttendanceContactsCount = async () => {
   try {
-    return await ChatRepository.getInAttendanceContactsCount({ clinic_id });
+    return await ChatRepository.getInAttendanceContactsCount();
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
 };
 
 const getAllContactsBeingAttended = async ({
-  clinic_id,
   role,
   page = 1,
   limit = 15,
@@ -130,7 +125,6 @@ const getAllContactsBeingAttended = async ({
 }) => {
   try {
     const result = await ChatRepository.getAllContactsBeingAttended({
-      clinic_id,
       role,
       page,
       limit,
@@ -152,7 +146,7 @@ const getAllContactsBeingAttended = async ({
   }
 };
 
-const searchContacts = async ({ clinic_id, query, page, limit, role, user_id, filters = {} }) => {
+const searchContacts = async ({ query, page, limit, role, user_id, filters = {} }) => {
   try {
     const cleanedQuery = normalizeQuery(query);
     const hasLetter = /[a-zA-Z]/.test(cleanedQuery);
@@ -161,14 +155,13 @@ const searchContacts = async ({ clinic_id, query, page, limit, role, user_id, fi
     const phone = cleanedQuery && !hasLetter ? cleanedQuery : null;
 
     const contacts = await ChatRepository.searchContacts({
-      clinic_id,
       name,
       phone,
       page,
       limit,
       role,
       user_id,
-      filters, // Repassa os filtros para o repository
+      filters,
     });
 
     await attachReplyMessages(contacts);
@@ -259,36 +252,6 @@ const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
   }
 };
 
-const getAllContactsMessagesWithNoFilters = async ({ page = 1, limit = 15 }) => {
-  try {
-    const result = await ChatRepository.getAllContactsMessagesWithNoFilters({
-      page,
-      limit,
-    });
-
-    // Corrigir - deve retornar contacts, não contact
-    if (!result || !result.contacts) {
-      return {
-        contacts: [],
-        totalItems: 0,
-        totalPages: 0,
-      };
-    }
-
-    // Aplica os mesmos tratamentos dos outros métodos
-    await attachReplyMessages(result.contacts);
-    await signMessagesMediaUrls(result.contacts);
-
-    return {
-      contacts: result.contacts,
-      totalItems: result.totalItems,
-      totalPages: Math.ceil(result.totalItems / limit),
-    };
-  } catch (error) {
-    throw new Error(`Service error: ${error.message}`);
-  }
-};
-
 const getContactByPetOwnerIdOrPhone = async ({
   pet_owner_id,
   contact,
@@ -371,7 +334,6 @@ export default {
   getContactByPetOwnerId,
   getContactByContactId,
   getOrdersByContactId,
-  getAllContactsMessagesWithNoFilters,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getTestContactsCount,

--- a/src/app.js
+++ b/src/app.js
@@ -37,7 +37,7 @@ checkDatabaseConnection();
 const app = express();
 const httpServer = createServer(app);
 
-const { io, clinicConnections } = initializeSocket(httpServer);
+const { io } = initializeSocket(httpServer);
 
 app.use(cors(corsConfig));
 
@@ -57,7 +57,7 @@ app.use(express.json(jsonConfig));
 app.use(helmet());
 app.use(limiter);
 app.use('/api/', privateRoutes);
-app.use('/api', createSocketRoutes(io, clinicConnections));
+app.use('/api', createSocketRoutes(io));
 
 app.get('/', (_req, res) => {
   res.status(200).json({ message: '🚀 Server is running with WebSocket!' });

--- a/src/config/socket.js
+++ b/src/config/socket.js
@@ -1,8 +1,13 @@
 import { Server } from 'socket.io';
 import jwt from 'jsonwebtoken';
 
-const clinicConnections = new Map();
+// Refactor 2026-05-08: visão unificada — todos os usuários autenticados (apenas
+// 2 sócios hoje) entram em uma única sala global e veem todas as mensagens.
+// Se voltar multi-clinic no futuro, reintroduzir clinic-specific rooms.
+const MESSAGING_ROOM = 'messaging_global';
+
 const userLastSeen = new Map();
+const userSockets = new Map();
 
 function initializeSocket(httpServer) {
   const io = new Server(httpServer, {
@@ -50,124 +55,49 @@ function initializeSocket(httpServer) {
   });
 
   io.on('connection', (socket) => {
-    const { id: userId, clinic_id: clinicId, email } = socket.user;
+    const { id: userId } = socket.user;
     const userName = socket.user.name || 'Atendente';
-
-    // 🔥 CORREÇÃO: Verificar debugger ANTES de qualquer outra lógica
-    const isDebugUser = email === 'debuger@latta.app';
-    const userKey = `${userId}-${isDebugUser ? 'debug' : clinicId}`;
 
     console.log(`🔗 Atendente conectado: ${userName} (${userId})`);
 
-    if (isDebugUser) {
-      console.log(`🐛 USUÁRIO DEBUGGER DETECTADO - Modo Global Ativado`);
-      console.log(`📍 Email: ${email}`);
-    } else {
-      console.log(`📍 Clínica: ${clinicId}`);
+    // Throttle de reconexão muito rápida (loop de cliente)
+    const lastSeen = userLastSeen.get(userId);
+    if (lastSeen && Date.now() - lastSeen < 2000) {
+      console.log(`⚠️ Reconexão muito rápida para ${userId}, descartando.`);
+      socket.emit('connection_throttled', {
+        message: 'Aguarde antes de reconectar',
+        waitTime: 2000,
+      });
+      socket.disconnect(true);
+      return;
     }
 
-    // Verificar reconexão muito rápida (loop)
-    if (!isDebugUser) {
-      const lastSeen = userLastSeen.get(userKey);
-      if (lastSeen && Date.now() - lastSeen < 2000) {
-        console.log(
-          `⚠️ Conexão muito rápida detectada para ${userId}, possível loop. Aguardando...`,
-        );
-        socket.emit('connection_throttled', {
-          message: 'Aguarde antes de reconectar',
-          waitTime: 2000,
+    // Substitui conexão prévia do mesmo usuário (evita duplicar handlers e
+    // mensagens duplicadas no painel quando o navegador reabre o socket).
+    const existingSocketId = userSockets.get(userId);
+    if (existingSocketId && existingSocketId !== socket.id) {
+      const existingSocket = io.sockets.sockets.get(existingSocketId);
+      if (existingSocket) {
+        existingSocket.emit('connection_replaced', {
+          message: 'Sua conexão foi substituída por uma nova sessão',
         });
-        socket.disconnect(true);
-        return;
+        existingSocket.removeAllListeners();
+        existingSocket.disconnect(true);
       }
     }
+    userSockets.set(userId, socket.id);
 
-    // 🔥 LÓGICA SEPARADA: Debugger vs Usuário Normal
-    if (isDebugUser) {
-      // ==========================================
-      // DEBUGGER: Entra APENAS na sala global
-      // ==========================================
+    socket.join(MESSAGING_ROOM);
+    console.log(`✅ Usuário ${userName} adicionado à sala '${MESSAGING_ROOM}'`);
 
-      const existingDebugSockets = Array.from(io.sockets.sockets.values()).filter(
-        (s) => s.user?.email === 'debuger@latta.app',
-      );
+    // Notifica os outros conectados
+    socket.to(MESSAGING_ROOM).emit('attendant_connected', {
+      userId,
+      userName,
+      timestamp: new Date(),
+    });
 
-      console.log(`🐛 Total de debugers conectados: ${existingDebugSockets.length}`);
-
-      socket.join('debug_global');
-      console.log(`✅ Debugger adicionado à sala 'debug_global'`);
-      console.log(`📊 Salas do socket:`, Array.from(socket.rooms));
-
-      // Notificar sobre modo debug
-      socket.emit('debug_mode_active', {
-        message: 'Modo debug ativo - você receberá mensagens de todas as clínicas',
-        timestamp: new Date(),
-      });
-    } else {
-      // ==========================================
-      // USUÁRIO NORMAL: Validar clinic_id
-      // ==========================================
-      if (!clinicId) {
-        console.error(`❌ Usuário ${userId} sem clinic_id`);
-        socket.emit('connection_error', {
-          error: 'Usuário sem clínica associada',
-        });
-        socket.disconnect(true);
-        return;
-      }
-
-      // Gerenciar conexões da clínica
-      if (!clinicConnections.has(clinicId)) {
-        clinicConnections.set(clinicId, new Map());
-      }
-
-      const clinicUsers = clinicConnections.get(clinicId);
-      const existingConnection = clinicUsers.get(userId);
-
-      if (existingConnection) {
-        console.log(`⚠️ Substituindo conexão existente do usuário ${userId}`);
-
-        const existingSocket = io.sockets.sockets.get(existingConnection.socketId);
-        if (existingSocket && existingSocket.id !== socket.id) {
-          existingSocket.emit('connection_replaced', {
-            message: 'Sua conexão foi substituída por uma nova sessão',
-          });
-          existingSocket.removeAllListeners();
-          existingSocket.disconnect(true);
-        }
-      }
-
-      // Adicionar nova conexão
-      clinicUsers.set(userId, {
-        socketId: socket.id,
-        userName,
-        connectedAt: new Date(),
-        isActive: true,
-      });
-
-      socket.join(`clinic_${clinicId}`);
-      console.log(`✅ Usuário adicionado à sala 'clinic_${clinicId}'`);
-      console.log(`📊 Conexões ativas na clínica ${clinicId}: ${clinicUsers.size}`);
-
-      // Tambem entra em debug_global pra capturar mensagens de contacts SEM
-      // clinic_id (leads novos, conversas onde o user nunca foi vinculado a
-      // uma clinic). socketRoutes.js:155-157 emite essas mensagens APENAS
-      // pra debug_global — sem esse join, o operador so via depois de F5.
-      // Trade-off: se houver multi-clinic, esse user vera leads de outras
-      // clinics. Hoje so existe Suporte Latta como clinic real, entao OK.
-      socket.join('debug_global');
-      console.log(`✅ Usuário adicionado à sala 'debug_global' (catch-all leads sem clinic)`);
-      console.log(`📊 Salas do socket:`, Array.from(socket.rooms));
-
-      // Notificar outros atendentes
-      socket.to(`clinic_${clinicId}`).emit('attendant_connected', {
-        userId,
-        userName,
-        timestamp: new Date(),
-      });
-    }
-
-    userLastSeen.set(userKey, Date.now());
+    userLastSeen.set(userId, Date.now());
 
     // Rate limiting para ping/pong
     let lastPing = 0;
@@ -228,34 +158,23 @@ function initializeSocket(httpServer) {
     const handleDisconnection = (reason) => {
       console.log(`❌ Atendente desconectado: ${userName} - Motivo: ${reason}`);
 
-      userLastSeen.set(userKey, Date.now());
+      userLastSeen.set(userId, Date.now());
 
       if (heartbeatInterval) {
         clearInterval(heartbeatInterval);
       }
 
-      // Cleanup apenas para usuários normais (não debugger)
-      if (!isDebugUser && clinicId && clinicConnections.has(clinicId)) {
-        const currentConnection = clinicConnections.get(clinicId).get(userId);
-        if (currentConnection && currentConnection.socketId === socket.id) {
-          clinicConnections.get(clinicId).delete(userId);
-
-          if (clinicConnections.get(clinicId).size === 0) {
-            clinicConnections.delete(clinicId);
-          }
-
-          socket.to(`clinic_${clinicId}`).emit('attendant_disconnected', {
-            userId,
-            userName,
-            timestamp: new Date(),
-          });
-
-          console.log(
-            `📊 Conexões restantes na clínica ${clinicId}:`,
-            clinicConnections.get(clinicId)?.size || 0,
-          );
-        }
+      // Limpa o pointer só se ainda for este socket (uma reconexão substituta
+      // pode ter acabado de re-setar pra um id novo).
+      if (userSockets.get(userId) === socket.id) {
+        userSockets.delete(userId);
       }
+
+      socket.to(MESSAGING_ROOM).emit('attendant_disconnected', {
+        userId,
+        userName,
+        timestamp: new Date(),
+      });
     };
 
     socket.on('disconnect', handleDisconnection);
@@ -269,8 +188,6 @@ function initializeSocket(httpServer) {
     // Confirmar conexão
     socket.emit('connection_confirmed', {
       userId,
-      clinicId: clinicId || 'debug',
-      isDebugMode: isDebugUser,
       timestamp: Date.now(),
       rooms: Array.from(socket.rooms),
       message: 'Conexão estabelecida com sucesso',
@@ -286,14 +203,14 @@ function initializeSocket(httpServer) {
     const now = Date.now();
     const CLEANUP_THRESHOLD = 300000;
 
-    for (const [userKey, lastSeen] of userLastSeen.entries()) {
-      if (now - lastSeen > CLEANUP_THRESHOLD) {
-        userLastSeen.delete(userKey);
+    for (const [userId, lastSeenAt] of userLastSeen.entries()) {
+      if (now - lastSeenAt > CLEANUP_THRESHOLD) {
+        userLastSeen.delete(userId);
       }
     }
   }, 60000);
 
-  return { io, clinicConnections };
+  return { io, MESSAGING_ROOM };
 }
 
-export { initializeSocket };
+export { initializeSocket, MESSAGING_ROOM };


### PR DESCRIPTION
## Summary

Remove o filtro por \`clinic_id\` e a logica especial de \`debuger@latta.app\` em queries de mensageria, controllers, service e socket. Todo usuário autenticado passa a ver tudo — visão unificada pareada com \`Latta-app/frontend#78\`.

## Mudanças

### Repository (\`chat-history.repository.js\`)
- \`getAllContactsWithMessages\` e \`getAllContactsBeingAttended\`: removem INNER JOIN \`pet_owner_clinics\` e o filtro \`poc.clinic_id\` em todas as subqueries (base + tags + responsibility + unread)
- \`searchContacts\`: remove \`clinic_id\` do whereConditions e dos filtros adicionais
- \`getInAttendanceContactsCount\` / \`getTestContactsCount\`: remove LEFT JOIN clinic, query simples direto em \`contacts\`
- **DELETA \`getAllContactsMessagesWithNoFilters\`** (era a fn dedicada do debug user — vira código morto agora que getAllContactsWithMessages retorna o mesmo conjunto)

### Service / Controller / Routes
- Remove parâmetro \`clinic_id\` de todas as chamadas relacionadas
- Deleta handler/service/repository de \`getAllContactsMessagesWithNoFilters\`
- Remove rotas \`/messages/getAllContactsMessagesWithNoFilters\` e \`/messages/loadMoreAllContacts\`

### Socket (\`config/socket.js\` + \`routes/socket/socketRoutes.js\`)
- Substitui salas \`clinic_\${id}\` + \`debug_global\` pela única \`MESSAGING_ROOM\` (\`messaging_global\`)
- Remove branching \`isDebugUser\` no connect/disconnect; substitui \`clinicConnections\` Map por \`userSockets\` (deduplica reconexão do mesmo usuário)
- Webhook \`/webhook/new-message\` emite só pra \`MESSAGING_ROOM\`

## Stats

- 7 arquivos, **+117 / −670** linhas

## Test plan

- [ ] Painel exibe todos os contatos (era restrito por clinic_id)
- [ ] Aba Luma (em-atendimento) e Geral mostram conjuntos corretos
- [ ] Aba Testes continua funcionando (filtro \`test-persona|%\` mantido)
- [ ] Filtros (tags, responsabilidade, não-lidas) aplicam
- [ ] WebSocket entrega \`new_message\` em tempo real pros 2 sócios
- [ ] Reconexão WS (refresh do navegador) substitui socket antigo sem dup

🤖 Generated with [Claude Code](https://claude.com/claude-code)