### PR TITLE
feat(backend): audit log LGPD em drilldown do dashboard

### DIFF
--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -1,4 +1,5 @@
 import DashboardService from '../services/dashboard.service.js';
+import DashboardAuditService from '../services/dashboard-audit.service.js';
 
 const parseRefresh = (q) => q?.refresh === '1' || q?.refresh === 'true';
 const parseIncludeTest = (q) => q?.include_test === 'true';
@@ -114,6 +115,16 @@ const getContactDrilldown = async (req, res) => {
       });
     }
     const result = await DashboardService.getContactDrilldown({ phone });
+
+    // Audit LGPD: registra quem (req.user) abriu drilldown de quem (phone).
+    // Fire-and-forget — não bloqueia response.
+    DashboardAuditService.logAudit({
+      userId: req.user?.id,
+      userEmail: req.user?.email,
+      action: 'drilldown_open',
+      targetPhone: phone,
+      targetPetOwnerId: result?.pet_owner?.id,
+    });
 
     return res.status(200).json({
       code: 'DASHBOARD_DRILLDOWN_RETRIEVED',

--- a/src/api/services/dashboard-audit.service.js
+++ b/src/api/services/dashboard-audit.service.js
@@ -1,0 +1,37 @@
+// dashboard-audit.service.js
+// Audit trail LGPD do dashboard. Fire-and-forget — nunca bloqueia a
+// response do controller. Insere via PostgREST com service_role.
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const AUDIT_URL = `${SUPABASE_URL}/rest/v1/dashboard_audit_log`;
+
+const logAudit = ({ userId, userEmail, action, targetPhone, targetPetOwnerId, metadata } = {}) => {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) return;
+  if (!userId || !action) return;
+
+  const body = {
+    user_id: userId,
+    user_email: userEmail || null,
+    action,
+    target_phone: targetPhone || null,
+    target_pet_owner_id: targetPetOwnerId || null,
+    metadata: metadata || null,
+  };
+
+  // fire-and-forget: nao await
+  fetch(AUDIT_URL, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal',
+    },
+    body: JSON.stringify(body),
+  }).catch((err) => {
+    console.error('Failed to write dashboard audit log:', err?.message);
+  });
+};
+
+export default { logAudit };


### PR DESCRIPTION
## Summary
\`getContactDrilldown\` agora loga audit em \`dashboard_audit_log\` (fire-and-forget) com {userId, userEmail, action='drilldown_open', targetPhone, targetPetOwnerId}.

Não bloqueia a response do controller. Em caso de falha do insert, console.error mas request continua normal.

## Stack relacionado
- Tabela criada em monorepo PR #282
- Frontend faz mascaramento + toggle reveal — feat/dashboard-phone-masking

## Test plan
- [ ] Subir backend
- [ ] Abrir drilldown, conferir SELECT * FROM dashboard_audit_log retorna nova linha

🤖 Generated with [Claude Code](https://claude.com/claude-code)