### PR TITLE
feat(clinic-portal): PATCH /scheduling/{cancel,no-show,reschedule} via EF (fatia 04 be)

### DIFF
--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -1,4 +1,5 @@
 import SchedulingService from '../services/scheduling.service.js';
+import MerchantSchedulingAgentService from '../services/merchant-scheduling-agent.service.js';
 import { validateSchedulingUpdate } from '../validators/scheduling.validations.js';
 import {
   redactAppointmentForClinic,
@@ -235,20 +236,140 @@ const cancelScheduling = async (req, res) => {
   try {
     const { id } = req.params;
     const scheduling = await SchedulingService.getSchedulingById({ id });
-    if (req.user.role === 'petOwner' && scheduling.pet_owner_id !== req.user.id) {
+    if (getRoleString(req) === 'petOwner' && scheduling.pet_owner_id !== req.user.id) {
       return res.status(403).json({
         code: 'FORBIDDEN',
         message: 'Você não tem permissão para cancelar este agendamento',
       });
     }
-    const canceled = await SchedulingService.cancelScheduling({ id, actor: actorOf(req) });
+    if (isClinicRole(req)) {
+      const jwtClinicId = getClinicId(req);
+      if (!jwtClinicId || scheduling.clinic_id !== jwtClinicId) {
+        return res.status(403).json({
+          code: 'CLINIC_FORBIDDEN',
+          message: 'Agendamento não pertence à sua clínica',
+        });
+      }
+    }
+
+    const reason = req.body?.reason || 'cancelado pela clinica via painel';
+
+    // Latta (source=latta): chama EF merchant-scheduling-agent que dispara
+    // template pro tutor + transita state. External (source=external): UPDATE
+    // direto no banco, sem notificacao (tutor da clinica nao usa WhatsApp Latta).
+    if (scheduling.source === 'latta') {
+      await MerchantSchedulingAgentService.cancelByMerchant({ sessionId: id, reason });
+    } else {
+      await SchedulingService.cancelScheduling({ id, actor: actorOf(req) });
+    }
+    const canceled = await SchedulingService.getSchedulingById({ id });
+
     logFromReq(req, 'scheduling_cancelled', { appointment_id: id, source: scheduling.source });
     return res.status(200).json({
       code: 'SCHEDULING_CANCELED',
-      data: canceled,
+      data: isClinicRole(req) ? redactAppointmentForClinic(canceled) : canceled,
     });
   } catch (error) {
     return handleError(res, error, { action: 'canceling scheduling', code: 'CANCEL_ERROR' });
+  }
+};
+
+const noShowScheduling = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const scheduling = await SchedulingService.getSchedulingById({ id });
+    if (isClinicRole(req)) {
+      const jwtClinicId = getClinicId(req);
+      if (!jwtClinicId || scheduling.clinic_id !== jwtClinicId) {
+        return res.status(403).json({
+          code: 'CLINIC_FORBIDDEN',
+          message: 'Agendamento não pertence à sua clínica',
+        });
+      }
+    }
+
+    const reason = req.body?.reason || 'tutor nao compareceu';
+
+    if (scheduling.source === 'latta') {
+      await MerchantSchedulingAgentService.noShowByMerchant({ sessionId: id, reason });
+    } else {
+      // External: UPDATE state direto no banco (NO_SHOW), sem template
+      await SchedulingService.updateScheduling({ id, schedulingData: {} });
+      await import('../../config/postgres.js').then(({ pgQuery }) =>
+        pgQuery(
+          `UPDATE scheduling_sessions SET state='NO_SHOW',
+             state_history = COALESCE(state_history, '[]'::jsonb)
+               || jsonb_build_array(jsonb_build_object('at', now(), 'state', 'NO_SHOW', 'source', $2::text, 'reason', $3::text)),
+             updated_at = now()
+           WHERE id = $1`,
+          [id, actorOf(req), reason],
+        ),
+      );
+    }
+    const updated = await SchedulingService.getSchedulingById({ id });
+
+    logFromReq(req, 'scheduling_no_show', { appointment_id: id, source: scheduling.source });
+    return res.status(200).json({
+      code: 'SCHEDULING_NO_SHOW',
+      data: isClinicRole(req) ? redactAppointmentForClinic(updated) : updated,
+    });
+  } catch (error) {
+    return handleError(res, error, { action: 'marking no-show', code: 'NO_SHOW_ERROR' });
+  }
+};
+
+const rescheduleScheduling = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { new_scheduled_date, new_scheduled_service, reason } = req.body || {};
+
+    if (!new_scheduled_date) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: 'new_scheduled_date é obrigatório (ISO 8601)',
+      });
+    }
+
+    const scheduling = await SchedulingService.getSchedulingById({ id });
+    if (isClinicRole(req)) {
+      const jwtClinicId = getClinicId(req);
+      if (!jwtClinicId || scheduling.clinic_id !== jwtClinicId) {
+        return res.status(403).json({
+          code: 'CLINIC_FORBIDDEN',
+          message: 'Agendamento não pertence à sua clínica',
+        });
+      }
+    }
+
+    if (scheduling.source === 'latta') {
+      await MerchantSchedulingAgentService.rescheduleByMerchant({
+        sessionId: id,
+        newScheduledDate: new_scheduled_date,
+        newScheduledService: new_scheduled_service,
+        reason: reason || 'remarcado pela clinica via painel',
+      });
+    } else {
+      await SchedulingService.updateScheduling({
+        id,
+        schedulingData: {
+          scheduled_date: new_scheduled_date,
+          ...(new_scheduled_service ? { scheduled_service: new_scheduled_service } : {}),
+        },
+      });
+    }
+    const updated = await SchedulingService.getSchedulingById({ id });
+
+    logFromReq(req, 'scheduling_rescheduled', {
+      appointment_id: id,
+      source: scheduling.source,
+      new_date: new_scheduled_date,
+    });
+    return res.status(200).json({
+      code: 'SCHEDULING_RESCHEDULED',
+      data: isClinicRole(req) ? redactAppointmentForClinic(updated) : updated,
+    });
+  } catch (error) {
+    return handleError(res, error, { action: 'rescheduling', code: 'RESCHEDULE_ERROR' });
   }
 };
 
@@ -288,6 +409,8 @@ export default {
   getSchedulingById,
   updateScheduling,
   cancelScheduling,
+  noShowScheduling,
+  rescheduleScheduling,
   confirmScheduling,
   deleteScheduling,
 };

--- a/src/api/routes/private/scheduling.routes.js
+++ b/src/api/routes/private/scheduling.routes.js
@@ -68,6 +68,22 @@ router.patch(
   SchedulingController.cancelScheduling,
 );
 
+// Marcar no-show (tutor nao compareceu)
+router.patch(
+  '/:id/no-show',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'clinic']),
+  SchedulingController.noShowScheduling,
+);
+
+// Remarcar agendamento
+router.patch(
+  '/:id/reschedule',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'clinic']),
+  SchedulingController.rescheduleScheduling,
+);
+
 // Confirmar um agendamento
 router.patch(
   '/:id/confirm',

--- a/src/api/services/merchant-scheduling-agent.service.js
+++ b/src/api/services/merchant-scheduling-agent.service.js
@@ -1,0 +1,51 @@
+// merchant-scheduling-agent.service.js
+// HTTP client pra invocar operações da EF merchant-scheduling-agent.
+// Usado pelos endpoints PATCH /scheduling/:id/{cancel,no-show,reschedule}
+// quando role=clinic dispara via painel.
+//
+// Em vez de mexer no DB direto (que era o padrão antigo do cancel),
+// chama a EF que faz: UPDATE state + state_history + dispara template
+// pro tutor via WhatsApp. Garante que o agent fica em sync.
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const EF_URL = `${SUPABASE_URL}/functions/v1/merchant-scheduling-agent`;
+
+const callEf = async (payload) => {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('SUPABASE env vars ausentes — EF call abortada');
+  }
+  const res = await fetch(EF_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json().catch(() => null);
+  if (!res.ok || !body?.success) {
+    const err = new Error(body?.error || `EF returned ${res.status}`);
+    err.status = res.status;
+    err.efDetail = body;
+    throw err;
+  }
+  return body;
+};
+
+export const cancelByMerchant = ({ sessionId, reason }) =>
+  callEf({ operation: 'cancel_by_merchant', session_id: sessionId, reason });
+
+export const noShowByMerchant = ({ sessionId, reason }) =>
+  callEf({ operation: 'no_show_by_merchant', session_id: sessionId, reason });
+
+export const rescheduleByMerchant = ({ sessionId, newScheduledDate, newScheduledService, reason }) =>
+  callEf({
+    operation: 'reschedule_by_merchant',
+    session_id: sessionId,
+    new_scheduled_date: newScheduledDate,
+    new_scheduled_service: newScheduledService,
+    reason,
+  });
+
+export default { cancelByMerchant, noShowByMerchant, rescheduleByMerchant };


### PR DESCRIPTION
Backend Express expoe 2 endpoints novos + reescreve cancel pra disparar template Latta -> tutor via EF merchant-scheduling-agent. Depende de [Matheus3FY/Latta#375](https://github.com/Matheus3FY/Latta/pull/375) (ja mergeado e deployed).

## Endpoints

| Método | Path | Comportamento |
|---|---|---|
| PATCH | `/scheduling/:id/cancel` | source=latta → EF cancel_by_merchant (template + state). source=external → UPDATE direto |
| PATCH | `/scheduling/:id/no-show` (NOVO) | source=latta → EF no_show_by_merchant. source=external → SQL inline state=NO_SHOW |
| PATCH | `/scheduling/:id/reschedule` (NOVO) | source=latta → EF reschedule_by_merchant. external → UPDATE scheduled_date |

Body comum: `{ reason? }`. Reschedule também: `{ new_scheduled_date (ISO), new_scheduled_service? }`.

## Mudanças

- `services/merchant-scheduling-agent.service.js` (NOVO): HTTP client pra EF (service_role auth)
- `controllers/scheduling.controller.js`: routing por `source` em cancel/no-show/reschedule, redactor pra role clinic, clinic_id JWT check
- `routes/private/scheduling.routes.js`: 2 routes novas com `checkRole(['admin','superAdmin','clinic'])`

Activity log gravado: `scheduling_cancelled` / `scheduling_no_show` / `scheduling_rescheduled` com `source` no event_data.

## Test plan

- [ ] Deploy backend EC2
- [ ] Smoke: PATCH /scheduling/:id/cancel num agendamento Latta → tutor recebe template `agendamento_cancelado_pelo_estab_v1`
- [ ] Smoke no-show: tutor recebe `agendamento_no_show_pelo_estab_v1`
- [ ] Smoke reschedule: tutor recebe `agendamento_remarcado_pelo_estab_v1` com nova data

Refs: docs/issues/clinic-portal/issues/04-actions-cancel-noshow-reschedule-templates.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)