### PR TITLE
feat(messaging): aba B2B no painel (clínicas separadas)

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -419,6 +419,60 @@ const getTestContactsCount = async (req, res) => {
   }
 };
 
+const getAllB2bContacts = async (req, res) => {
+  try {
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 15;
+    const { id, role } = req.user;
+
+    const responsibility = req.query.responsibility === 'true';
+    const unread = req.query.unread === 'true';
+    const tags = req?.query?.tags ? req.query.tags.split(',').filter((tag) => tag.trim()) : [];
+
+    const filters = { responsibility, unread, tags };
+
+    const result = await ChatService.getAllB2bContacts({
+      user_id: id,
+      role: role.role,
+      page,
+      limit,
+      filters,
+    });
+
+    return res.status(200).json({
+      code: 'B2B_CONTACTS_RETRIEVED',
+      data: result.contacts,
+    });
+  } catch (error) {
+    console.error('Error retrieving b2b contacts:', error);
+    return res.status(500).json({
+      code: 'B2B_CONTACTS_RETRIEVAL_ERROR',
+      message: error.message,
+    });
+  }
+};
+
+const getB2bContactsCount = async (req, res) => {
+  try {
+    const { role } = req.user;
+
+    const result = await ChatService.getB2bContactsCount({
+      role: role.role,
+    });
+
+    return res.status(200).json({
+      code: 'B2B_CONTACTS_COUNT_RETRIEVED',
+      data: { count: result.count },
+    });
+  } catch (error) {
+    console.error('Error retrieving b2b contacts count:', error);
+    return res.status(500).json({
+      code: 'B2B_CONTACTS_COUNT_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getInAttendanceContactsCount = async (_req, res) => {
   try {
     const result = await ChatService.getInAttendanceContactsCount();
@@ -508,7 +562,9 @@ export default {
   getOrdersByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
+  getAllB2bContacts,
   getTestContactsCount,
+  getB2bContactsCount,
   getInAttendanceContactsCount,
   markAsAnswered,
   getMessagesDaysSummary,

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -39,6 +39,14 @@ const TEST_CONTACT_IDS_SUBQUERY = `(
   WHERE c.cellphone ~ '^5500000000[0-9]{3}$'
 )`;
 
+// B2B contacts (clínicas): qualquer contact com chat_history cujo path
+// começa com 'merchant-scheduling-agent|' — pattern do agent que conversa
+// com clínica em nome do tutor. Tab "B2B" no painel.
+const B2B_CONTACT_IDS_SUBQUERY = `(
+  SELECT DISTINCT ch.contact_id FROM chat_history ch
+  WHERE ch.path LIKE 'merchant-scheduling-agent|%' AND ch.contact_id IS NOT NULL
+)`;
+
 const RECENT_ORDERS_LIMIT = 10;
 const ORDER_LIST_ATTRS = [
   'id',
@@ -84,6 +92,16 @@ const buildTestChatFilter = (testFilter = 'exclude') => {
   return { op: 'notIn' };
 };
 
+// Mesmo pattern do testFilter pra aba B2B:
+//   'only'    -> mostra SO clinicas
+//   'exclude' -> exclui clinicas das outras abas (Geral/Luma)
+//   'none'    -> nao filtra
+const buildB2bChatFilter = (b2bFilter = 'exclude') => {
+  if (b2bFilter === 'only') return { op: 'in' };
+  if (b2bFilter === 'none') return null;
+  return { op: 'notIn' };
+};
+
 const getAllContactsWithMessages = async ({
   role,
   page = 1,
@@ -91,6 +109,7 @@ const getAllContactsWithMessages = async ({
   user_id,
   filters = {},
   testFilter = 'exclude',
+  b2bFilter = 'exclude',
 }) => {
   try {
     const offset = (page - 1) * limit;
@@ -99,6 +118,7 @@ const getAllContactsWithMessages = async ({
     const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
     const chatHistoryWhere = shouldFilterLatta ? { path: { [Op.ne]: 'latta' } } : {};
     const testChatFilter = buildTestChatFilter(testFilter);
+    const b2bChatFilter = buildB2bChatFilter(b2bFilter);
 
     // Filtro base: contatos QUE TÊM pelo menos uma chat_history. Sem corte por
     // clinic_id — visão unificada (refactor 2026-05-08): só dois sócios usam o
@@ -139,6 +159,17 @@ const getAllContactsWithMessages = async ({
         id: {
           [testChatFilter.op === 'in' ? Op.in : Op.notIn]: Sequelize.literal(
             TEST_CONTACT_IDS_SUBQUERY,
+          ),
+        },
+      });
+    }
+
+    // FILTRO B2B (clinicas) — mesmo pattern do testFilter
+    if (b2bChatFilter) {
+      additionalConditions.push({
+        id: {
+          [b2bChatFilter.op === 'in' ? Op.in : Op.notIn]: Sequelize.literal(
+            B2B_CONTACT_IDS_SUBQUERY,
           ),
         },
       });
@@ -411,6 +442,7 @@ const getAllContactsBeingAttended = async ({
     const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
     const chatHistoryWhere = shouldFilterLatta ? { path: { [Op.ne]: 'latta' } } : {};
     const testChatFilter = buildTestChatFilter(testFilter);
+    const b2bChatFilter = buildB2bChatFilter(b2bFilter);
 
     // Filtro base: contatos em atendimento humano (Luma) com chat_history.
     // Sem corte por clinic_id — visão unificada (refactor 2026-05-08).
@@ -440,6 +472,17 @@ const getAllContactsBeingAttended = async ({
         id: {
           [testChatFilter.op === 'in' ? Op.in : Op.notIn]: Sequelize.literal(
             TEST_CONTACT_IDS_SUBQUERY,
+          ),
+        },
+      });
+    }
+
+    // FILTRO B2B (clinicas) — mesmo pattern do testFilter
+    if (b2bChatFilter) {
+      additionalConditions.push({
+        id: {
+          [b2bChatFilter.op === 'in' ? Op.in : Op.notIn]: Sequelize.literal(
+            B2B_CONTACT_IDS_SUBQUERY,
           ),
         },
       });
@@ -1836,6 +1879,34 @@ const getTestContactsCount = async ({ role }) => {
   }
 };
 
+const getB2bContactsCount = async ({ role }) => {
+  try {
+    const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
+
+    // Conta contatos (clínicas) com ao menos 1 chat do merchant-scheduling-agent.
+    const [result] = await Contact.sequelize.query(
+      `
+      SELECT COUNT(DISTINCT c.id)::int AS count
+      FROM contacts c
+      WHERE EXISTS (
+        SELECT 1 FROM chat_history ch
+        WHERE ch.contact_id = c.id
+        AND ch.path LIKE 'merchant-scheduling-agent|%'
+        ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
+      )
+      `,
+      {
+        type: Sequelize.QueryTypes.SELECT,
+      },
+    );
+
+    return { count: result?.count || 0 };
+  } catch (error) {
+    console.error('❌ ERRO getB2bContactsCount:', error.message);
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 // Resumo de dias com mensagens pra um contato — alimenta o date picker da
 // mensageria. Agrupa por dia em America/Sao_Paulo (timezone do operador) e
 // aplica o mesmo filtro de role usado em getContactByPetOwnerId/getContactByContactId.
@@ -1910,6 +1981,7 @@ export default {
   getContactByPetOwnerIdOrPhone,
   getOrdersByContactId,
   getTestContactsCount,
+  getB2bContactsCount,
   getInAttendanceContactsCount,
   getMessagesDaysSummary,
 };

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -32,6 +32,21 @@ router.get(
   ChatController.getTestContactsCount,
 );
 
+// Aba B2B: contacts de clinicas (chat path 'merchant-scheduling-agent|%')
+router.get(
+  '/messages/getAllB2bContacts',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getAllB2bContacts,
+);
+
+router.get(
+  '/messages/getB2bContactsCount',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getB2bContactsCount,
+);
+
 // Badge da aba "Luma" no painel — conta contacts.is_being_attended=true.
 router.get(
   '/messages/getInAttendanceContactsCount',

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -58,6 +58,7 @@ const getAllContactsWithMessages = async ({
   user_id,
   filters = {},
   testFilter = 'exclude',
+  b2bFilter = 'exclude',
 }) => {
   try {
     const result = await ChatRepository.getAllContactsWithMessages({
@@ -67,6 +68,7 @@ const getAllContactsWithMessages = async ({
       user_id,
       filters,
       testFilter,
+      b2bFilter,
     });
     const contacts = result.contacts;
 
@@ -97,12 +99,40 @@ const getAllTestContacts = async ({
     user_id,
     filters,
     testFilter: 'only',
+    b2bFilter: 'none',
+  });
+};
+
+// Aba B2B: clínicas (chat path 'merchant-scheduling-agent|%')
+const getAllB2bContacts = async ({
+  role,
+  page = 1,
+  limit = 15,
+  user_id,
+  filters = {},
+}) => {
+  return getAllContactsWithMessages({
+    role,
+    page,
+    limit,
+    user_id,
+    filters,
+    testFilter: 'none',
+    b2bFilter: 'only',
   });
 };
 
 const getTestContactsCount = async ({ role }) => {
   try {
     return await ChatRepository.getTestContactsCount({ role });
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
+const getB2bContactsCount = async ({ role }) => {
+  try {
+    return await ChatRepository.getB2bContactsCount({ role });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
@@ -336,7 +366,9 @@ export default {
   getOrdersByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
+  getAllB2bContacts,
   getTestContactsCount,
+  getB2bContactsCount,
   getInAttendanceContactsCount,
   markAsAnswered,
   getMessagesDaysSummary,


### PR DESCRIPTION
Operador precisa distinguir conversas com **clínica** (agent `merchant-scheduling-agent`) das conversas tutor-Latta. Hoje as clínicas caem em "Geral" como tutor normal.

Nova aba **B2B** exibida entre Luma e Testes quando há ≥1 contact clínica. Pattern espelhado da aba Testes — UNION de `path LIKE 'merchant-scheduling-agent|%'` em `chat_history`.

## Mudanças

- `chat-history.repository.js`: `B2B_CONTACT_IDS_SUBQUERY` + `buildB2bChatFilter` + `getB2bContactsCount`. Geral/Luma agora EXCLUEM b2b por default
- `chat-history.service.js`: `getAllB2bContacts` (calls com `b2bFilter='only', testFilter='none'`)
- `chat-history.controller.js` + `routes`: `GET /messages/getAllB2bContacts` + `getB2bContactsCount`

Frontend: PR separado em Latta-app/frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)