### PR TITLE
feat(clinic-auth): login por phone (alem de email)

### DIFF
--- a/src/api/controllers/clinic-auth.controller.js
+++ b/src/api/controllers/clinic-auth.controller.js
@@ -21,9 +21,12 @@ const activateSchema = Joi.object({
 }).options({ stripUnknown: true });
 
 const loginSchema = Joi.object({
-  email: Joi.string().email().required(),
+  email: Joi.string().email(),
+  phone: Joi.string().pattern(/^\+?[\d\s().-]{8,20}$/),
   password: Joi.string().required(),
-}).options({ stripUnknown: true });
+})
+  .xor('email', 'phone') // exatamente um dos dois
+  .options({ stripUnknown: true });
 
 const forgotSchema = Joi.object({
   email: Joi.string().email().required(),

--- a/src/api/repositories/clinic-user.repository.js
+++ b/src/api/repositories/clinic-user.repository.js
@@ -11,6 +11,24 @@ export const findByEmail = async (email) => {
   return rows[0] ?? null;
 };
 
+// Login por phone: resolve via clinics.phone_normalized -> clinic_users.clinic_id.
+// Aceita phone com ou sem mascara — normaliza removendo nao-digitos.
+// Retorna apenas 1 (mais antigo) se houver multiplos clinic_users pra mesma clinic.
+export const findByPhone = async (phone) => {
+  const normalized = String(phone || '').replace(/\D+/g, '');
+  if (!normalized) return null;
+  const { rows } = await pgQuery(
+    `SELECT ${COLUMNS.split(',').map((c) => `cu.${c.trim()}`).join(', ')}
+     FROM clinic_users cu
+     JOIN clinics c ON c.id = cu.clinic_id
+     WHERE c.phone_normalized = $1
+     ORDER BY cu.created_at ASC
+     LIMIT 1`,
+    [normalized],
+  );
+  return rows[0] ?? null;
+};
+
 export const findByActivationToken = async (token) => {
   const { rows } = await pgQuery(
     `SELECT ${COLUMNS} FROM clinic_users WHERE activation_token = $1 LIMIT 1`,
@@ -107,6 +125,7 @@ export const getClinic = async (clinicId) => {
 
 export default {
   findByEmail,
+  findByPhone,
   findByActivationToken,
   findByResetToken,
   upsertForActivation,

--- a/src/api/services/clinic-auth.service.js
+++ b/src/api/services/clinic-auth.service.js
@@ -122,15 +122,19 @@ export const activate = async ({ token, password }) => {
   return { user: activated };
 };
 
-export const login = async ({ email, password }) => {
-  if (!email || !password) {
-    const e = new Error('email e password são obrigatórios');
+export const login = async ({ email, phone, password }) => {
+  // Aceita email OU phone como identificador. UX preferido pos-fatia 4: phone
+  // (clinic_users.email e placeholder synthetic gerado pelo bridge B2B).
+  if ((!email && !phone) || !password) {
+    const e = new Error('email/phone e password são obrigatórios');
     e.code = 'INVALID_CREDENTIALS';
     throw e;
   }
-  const user = await ClinicUserRepository.findByEmail(email);
+  const user = phone
+    ? await ClinicUserRepository.findByPhone(phone)
+    : await ClinicUserRepository.findByEmail(email);
   if (!user || !user.password_hash) {
-    const e = new Error('Email ou senha inválidos');
+    const e = new Error('Credenciais inválidas');
     e.code = 'INVALID_CREDENTIALS';
     throw e;
   }


### PR DESCRIPTION
## Summary

Bridge B2B gera `clinic_users` com email placeholder synthetic (`clinic-<short>@latta.b2b`) — inútil pra UX de login. Phone do estabelecimento já existe em `clinics.phone_normalized`, então adicionar `findByPhone` resolve via JOIN clinic_users -> clinics e habilita login sem expor email placeholder.

- `clinic-user.repository.js`: novo `findByPhone(phone)` (normaliza não-dígitos + JOIN clinics).
- `clinic-auth.service.js`: `login` aceita `{phone, password}` OU `{email, password}`.
- `clinic-auth.controller.js`: Joi schema com `.xor(email, phone)` + password.

## Test plan
- POST `/api/clinic-auth/login` com `{phone:"5531999155797", password:"..."}` retorna 200 + token.
- POST com `{email:..., password:...}` (legado) continua funcionando.
- POST sem nenhum dos dois retorna 400 VALIDATION_ERROR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)