### PR TITLE
fix(clinic-auth): normalize BR phone no login (Bug 2 do e2e 2026-05-19)

### DIFF
--- a/src/api/repositories/clinic-user.repository.js
+++ b/src/api/repositories/clinic-user.repository.js
@@ -1,4 +1,5 @@
 import { pgQuery } from '../../config/postgres.js';
+import { normalizeBrPhone } from '../../utils/normalize-br-phone.js';
 
 const COLUMNS = `id, clinic_id, email, password_hash, activation_token, activation_token_expires_at,
   password_reset_token, password_reset_expires_at, activated_at, last_login_at, created_at, updated_at`;
@@ -12,10 +13,14 @@ export const findByEmail = async (email) => {
 };
 
 // Login por phone: resolve via clinics.phone_normalized -> clinic_users.clinic_id.
-// Aceita phone com ou sem mascara — normaliza removendo nao-digitos.
+// Aceita phone com ou sem mascara — normaliza via normalizeBrPhone pra obter
+// o formato canonico de 13 digitos (55 + DDD + 9 + 8) que o banco usa.
+// Bug 2 de 2026-05-19: a versao anterior so removia caracteres nao-numericos
+// e fazia match direto. Quando a clinica digitava 11 digitos (DDD+9+8 sem DDI),
+// query buscava por exemplo "31999155797" enquanto banco tem "5531999155797".
 // Retorna apenas 1 (mais antigo) se houver multiplos clinic_users pra mesma clinic.
 export const findByPhone = async (phone) => {
-  const normalized = String(phone || '').replace(/\D+/g, '');
+  const normalized = normalizeBrPhone(phone);
   if (!normalized) return null;
   const { rows } = await pgQuery(
     `SELECT ${COLUMNS.split(',').map((c) => `cu.${c.trim()}`).join(', ')}

--- a/src/utils/normalize-br-phone.js
+++ b/src/utils/normalize-br-phone.js
@@ -1,0 +1,44 @@
+// Normaliza phone BR pro formato canonico de 13 digitos: 55 + DDD(2) + 9 + 8 digitos.
+//
+// Casos de entrada que precisamos cobrir (Bug 2 de 2026-05-19):
+//   - "5531999155797"   (13 digitos, canonico)            -> "5531999155797"
+//   - "31999155797"     (11 digitos, DDD+9+8, sem DDI)    -> "5531999155797"
+//   - "553199915797"    (12 digitos, DDI+DDD+8, sem 9)    -> "5531999155797"
+//   - "3199915797"      (10 digitos, DDD+8, sem DDI+9)    -> "5531999155797"
+//   - "+55 31 99915-5797" (mascarado)                     -> "5531999155797"
+//
+// Casos fora do escopo (devolve digits-only sem transformar):
+//   - tudo que nao se enquadra (numeros internacionais, lixo, vazio)
+//
+// Inspirado em normalizeBrPhone do EF chat-history-logger mas mais completo
+// pq aqui recebemos input do usuario via formulario (mais variabilidade).
+
+export function normalizeBrPhone(raw) {
+  const digits = String(raw || '').replace(/\D+/g, '');
+  if (!digits) return '';
+
+  // 13 digitos com 55: ja canonico
+  if (digits.length === 13 && digits.startsWith('55')) {
+    return digits;
+  }
+
+  // 12 digitos com 55: falta o "9" entre DDD e numero (celular antigo)
+  if (digits.length === 12 && digits.startsWith('55')) {
+    return digits.slice(0, 4) + '9' + digits.slice(4);
+  }
+
+  // 11 digitos: DDD + 9 + 8 digitos, falta DDI 55
+  if (digits.length === 11) {
+    return '55' + digits;
+  }
+
+  // 10 digitos: DDD + 8 digitos, falta DDI 55 e o "9"
+  if (digits.length === 10) {
+    return '55' + digits.slice(0, 2) + '9' + digits.slice(2);
+  }
+
+  // Outros tamanhos: retorna digits-only sem transformar.
+  return digits;
+}
+
+export default normalizeBrPhone;


### PR DESCRIPTION
## Resumo

Fix do **Bug 2** do e2e real 2026-05-19: Iris ativou painel via magic link mas recebia "Não conseguimos entrar agora" ao tentar logar com phone + senha.

## Root cause

[`findByPhone`](src/api/repositories/clinic-user.repository.js#L17) em `clinic-user.repository.js` fazia apenas `String(phone).replace(/\D+/g, '')` e batia direto contra `clinics.phone_normalized`.

Quando o input tinha **11 dígitos** (DDD+9+8 sem DDI 55), query buscava por exemplo `"31999155797"`, mas o banco armazena no formato canônico de 13 dígitos com DDI: `"5531999155797"`. **MISS** → `findByPhone` retorna null → service joga `INVALID_CREDENTIALS` → frontend mostra mensagem genérica.

## Confirmação via SQL

```
clinic_users de Iris (clinic_id 9e6b8094...):
- password_hash: setado ✓
- activated_at: 2026-05-19 ✓
- last_login_at: NULL ❌ (nunca logou pq o lookup falhava antes do bcrypt.compare)
```

## Fix

- Novo util `src/utils/normalize-br-phone.js` cobrindo 4 formatos comuns:
  - `5531999155797` (13d canônico) → return as-is
  - `553199155797` (12d com DDI sem 9, celular antigo) → insere "9"
  - `31999155797` (11d sem DDI) → adiciona "55"
  - `3199155797` (10d sem DDI sem 9) → adiciona "55" + "9"
  - Máscaras (`+55 (31) 99915-5797`) também resolvem.
- `findByPhone` usa `normalizeBrPhone(phone)` antes do match.

## Test plan

Validação local com node inline (11/11 casos):

```
OK  13d canonico: '5531999155797' -> '5531999155797'
OK  11d sem DDI: '31999155797' -> '5531999155797'
OK  12d com DDI sem 9: '553199155797' -> '5531999155797'
OK  10d sem DDI sem 9: '3199155797' -> '5531999155797'
OK  mascarado completo: '+55 (31) 99915-5797' -> '5531999155797'
OK  mascarado 11d: '(31) 99915-5797' -> '5531999155797'
OK  vazio/null/undefined: ''
OK  só letras: 'abcdef' -> ''
OK  DDD 11 SP, 12d sem 9: '551199155797' -> '5511999155797'
```

Pós-deploy:

- [ ] Iris loga com `31999155797` + senha → expected: 200 CLINIC_LOGIN_SUCCESS
- [ ] Iris loga com email synthetic `clinic-9e6b8094adc1@latta.b2b` → expected: 200 (regressão check, login por email continua funcionando)
- [ ] Tentativa com phone inexistente → 401 INVALID_CREDENTIALS (sem leak de info)

## Não cobre

- Bug 1 (link regenerado) — fix no EF do scheduling agent, PR #429 lá.
- Bug 3 (relay loop pós-CONFIRMED) — fix no chat-engine, PR #430 lá.
- Email synthetic placeholder em `clinic_users` (decisão de UX, fora do escopo deste fix).

## Deploy

EC2 manual via skill `deploy-backend`. Sem migration. Reversível por revert + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)