### PR TITLE
feat(mensageria): suporte a environment prod/homolog (ADR-0007)

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -4,7 +4,7 @@ const getAllContactsWithMessages = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
-    const { id, role } = req.user;
+    const { id, role, environment } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -22,6 +22,7 @@ const getAllContactsWithMessages = async (req, res) => {
       page,
       limit,
       filters,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -41,7 +42,7 @@ const getAllContactsBeingAttended = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
-    const { id, role } = req.user;
+    const { id, role, environment } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -59,6 +60,7 @@ const getAllContactsBeingAttended = async (req, res) => {
       page,
       limit,
       filters,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -77,7 +79,7 @@ const getAllContactsBeingAttended = async (req, res) => {
 const searchContacts = async (req, res) => {
   try {
     const { query, page = 1, limit = 15 } = req.query;
-    const { id, role } = req.user;
+    const { id, role, environment } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -96,6 +98,7 @@ const searchContacts = async (req, res) => {
       role: role.role,
       user_id: id,
       filters,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -114,7 +117,7 @@ const searchContacts = async (req, res) => {
 const getContactByPetOwnerId = async (req, res) => {
   try {
     const { pet_owner_id } = req.params;
-    const { role } = req.user;
+    const { role, environment } = req.user;
     const { page = 1, limit = 20, before, after } = req.query;
 
     // Validação dos parâmetros
@@ -165,6 +168,7 @@ const getContactByPetOwnerId = async (req, res) => {
       limit: limitNum,
       before: before || null,
       after: after || null,
+      environment: environment || 'prod',
     });
 
     if (!result || !result.contact) {
@@ -191,7 +195,7 @@ const getContactByPetOwnerId = async (req, res) => {
 const getContactByContactId = async (req, res) => {
   try {
     const { contact_id } = req.params;
-    const { role } = req.user;
+    const { role, environment } = req.user;
     const { page = 1, limit = 20, before, after } = req.query;
 
     if (!contact_id) {
@@ -239,6 +243,7 @@ const getContactByContactId = async (req, res) => {
       limit: limitNum,
       before: before || null,
       after: after || null,
+      environment: environment || 'prod',
     });
 
     if (!result || !result.contact) {
@@ -265,6 +270,7 @@ const getContactByContactId = async (req, res) => {
 const getOrdersByContactId = async (req, res) => {
   try {
     const { contact_id } = req.params;
+    const { environment } = req.user;
     const { page = 1, limit = 10 } = req.query;
 
     if (!contact_id) {
@@ -288,6 +294,7 @@ const getOrdersByContactId = async (req, res) => {
       contact_id,
       page: pageNum,
       limit: limitNum,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -307,7 +314,7 @@ const getOrdersByContactId = async (req, res) => {
 const getContactByPetOwnerIdOrPhone = async (req, res) => {
   try {
     const { pet_owner_id, contact } = req.query;
-    const { role } = req.user;
+    const { role, environment } = req.user;
     const { page = 1, limit = 20 } = req.query;
 
     if (!pet_owner_id && !contact) {
@@ -342,6 +349,7 @@ const getContactByPetOwnerIdOrPhone = async (req, res) => {
       role: role.role,
       page: pageNum,
       limit: limitNum,
+      environment: environment || 'prod',
     });
 
     if (!result || !result.contact) {
@@ -369,7 +377,7 @@ const getAllTestContacts = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 15;
-    const { id, role } = req.user;
+    const { id, role, environment } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -383,6 +391,7 @@ const getAllTestContacts = async (req, res) => {
       page,
       limit,
       filters,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -400,10 +409,11 @@ const getAllTestContacts = async (req, res) => {
 
 const getTestContactsCount = async (req, res) => {
   try {
-    const { role } = req.user;
+    const { role, environment } = req.user;
 
     const result = await ChatService.getTestContactsCount({
       role: role.role,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -423,7 +433,7 @@ const getAllB2bContacts = async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 15;
-    const { id, role } = req.user;
+    const { id, role, environment } = req.user;
 
     const responsibility = req.query.responsibility === 'true';
     const unread = req.query.unread === 'true';
@@ -437,6 +447,7 @@ const getAllB2bContacts = async (req, res) => {
       page,
       limit,
       filters,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -454,10 +465,11 @@ const getAllB2bContacts = async (req, res) => {
 
 const getB2bContactsCount = async (req, res) => {
   try {
-    const { role } = req.user;
+    const { role, environment } = req.user;
 
     const result = await ChatService.getB2bContactsCount({
       role: role.role,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({
@@ -473,9 +485,12 @@ const getB2bContactsCount = async (req, res) => {
   }
 };
 
-const getInAttendanceContactsCount = async (_req, res) => {
+const getInAttendanceContactsCount = async (req, res) => {
   try {
-    const result = await ChatService.getInAttendanceContactsCount();
+    const { environment } = req.user || {};
+    const result = await ChatService.getInAttendanceContactsCount({
+      environment: environment || 'prod',
+    });
     return res.status(200).json({
       code: 'IN_ATTENDANCE_CONTACTS_COUNT_RETRIEVED',
       data: { count: result.count },
@@ -524,7 +539,7 @@ const markAsAnswered = async (req, res) => {
 // usa America/Sao_Paulo pra bater com o que o operador vê na tela.
 const getMessagesDaysSummary = async (req, res) => {
   try {
-    const { role } = req.user;
+    const { role, environment } = req.user;
     const { pet_owner_id = null, contact_id = null } = req.query;
 
     if (!pet_owner_id && !contact_id) {
@@ -538,6 +553,7 @@ const getMessagesDaysSummary = async (req, res) => {
       pet_owner_id,
       contact_id,
       role: role.role,
+      environment: environment || 'prod',
     });
 
     return res.status(200).json({

--- a/src/api/models/Users/UserModel.js
+++ b/src/api/models/Users/UserModel.js
@@ -55,6 +55,14 @@ const User = (sequelize) => {
         type: DataTypes.STRING(255),
         allowNull: true,
       },
+      environment: {
+        type: DataTypes.STRING(16),
+        allowNull: false,
+        defaultValue: 'prod',
+        validate: {
+          isIn: [['prod', 'homolog']],
+        },
+      },
       created_at: {
         type: DataTypes.DATE,
         allowNull: false,

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -53,6 +53,29 @@ const B2B_CONTACT_IDS_SUBQUERY = `(
   )
 )`;
 
+// Staging contacts: phones na whitelist staging_users (ADR-0007 Fatia 7).
+// Usado pra filtrar mensageria do admin web por environment:
+//   - environment='homolog': mostra APENAS contacts com cellphone em staging_users
+//   - environment='prod' (ou undefined): sem filtro (comportamento atual)
+// Helper centralizado pra evitar drift entre listing/count/search/detail.
+const STAGING_CONTACT_IDS_SUBQUERY = `(
+  SELECT DISTINCT c.id FROM contacts c
+  WHERE c.cellphone IN (SELECT phone FROM staging_users)
+)`;
+
+// Retorna a condicao Sequelize adequada pra adicionar em additionalConditions,
+// ou null pra deixar a query passar sem filtro de environment. Pra prod
+// (default), retorna null — preserva comportamento existente. Pra homolog,
+// retorna { id: { [Op.in]: STAGING_CONTACT_IDS_SUBQUERY } }.
+const buildStagingEnvironmentCondition = (Op, environment) => {
+  if (environment !== 'homolog') return null;
+  return {
+    id: {
+      [Op.in]: Sequelize.literal(STAGING_CONTACT_IDS_SUBQUERY),
+    },
+  };
+};
+
 const RECENT_ORDERS_LIMIT = 10;
 const ORDER_LIST_ATTRS = [
   'id',
@@ -116,6 +139,7 @@ const getAllContactsWithMessages = async ({
   filters = {},
   testFilter = 'exclude',
   b2bFilter = 'exclude',
+  environment = 'prod',
 }) => {
   try {
     const offset = (page - 1) * limit;
@@ -179,6 +203,14 @@ const getAllContactsWithMessages = async ({
           ),
         },
       });
+    }
+
+    // FILTRO DE ENVIRONMENT — ADR-0007 Fatia 7.
+    // Quando user.environment='homolog', mostra APENAS contacts em staging_users.
+    // Pra 'prod' (default), retorna null = sem filtro (preserva comportamento).
+    const stagingEnvCondition = buildStagingEnvironmentCondition(Op, environment);
+    if (stagingEnvCondition) {
+      additionalConditions.push(stagingEnvCondition);
     }
 
     // FILTRO DE TAGS - Condição OU entre as tags
@@ -440,6 +472,8 @@ const getAllContactsBeingAttended = async ({
   user_id,
   filters = {},
   testFilter = 'exclude',
+  b2bFilter = 'exclude',
+  environment = 'prod',
 }) => {
   try {
     const offset = (page - 1) * limit;
@@ -492,6 +526,12 @@ const getAllContactsBeingAttended = async ({
           ),
         },
       });
+    }
+
+    // FILTRO DE ENVIRONMENT — ADR-0007 Fatia 7. Veja getAllContactsWithMessages.
+    const stagingEnvCondition = buildStagingEnvironmentCondition(Op, environment);
+    if (stagingEnvCondition) {
+      additionalConditions.push(stagingEnvCondition);
     }
 
     // FILTRO DE TAGS - Condição OU entre as tags
@@ -747,6 +787,7 @@ const searchContacts = async ({
   role,
   user_id,
   filters = {},
+  environment = 'prod',
 }) => {
   try {
     const { Op } = Sequelize;
@@ -791,6 +832,12 @@ const searchContacts = async ({
 
     // Aplica os filtros adicionais (mesma lógica do getAllContacts)
     const additionalConditions = [];
+
+    // FILTRO DE ENVIRONMENT — ADR-0007 Fatia 7. Veja getAllContactsWithMessages.
+    const stagingEnvCondition = buildStagingEnvironmentCondition(Op, environment);
+    if (stagingEnvCondition) {
+      additionalConditions.push(stagingEnvCondition);
+    }
 
     // FILTRO DE TAGS - Condição OU entre as tags
     if (filters.tags && filters.tags.length > 0) {
@@ -1837,13 +1884,20 @@ const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
 
 // Conta contacts com is_being_attended=true (alimenta o badge da aba Luma).
 // Sem corte por clinic_id — visão unificada (refactor 2026-05-08).
-const getInAttendanceContactsCount = async () => {
+// environment (ADR-0007 Fatia 7): quando 'homolog', restringe a count a
+// contacts cujo cellphone esta em staging_users.
+const getInAttendanceContactsCount = async ({ environment = 'prod' } = {}) => {
   try {
+    const envFilter =
+      environment === 'homolog'
+        ? `AND c.cellphone IN (SELECT phone FROM staging_users)`
+        : '';
     const [result] = await Contact.sequelize.query(
       `
       SELECT COUNT(*)::int AS count
       FROM contacts c
       WHERE c.is_being_attended = true
+      ${envFilter}
       `,
       {
         type: Sequelize.QueryTypes.SELECT,
@@ -1856,9 +1910,13 @@ const getInAttendanceContactsCount = async () => {
   }
 };
 
-const getTestContactsCount = async ({ role }) => {
+const getTestContactsCount = async ({ role, environment = 'prod' }) => {
   try {
     const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
+    const envFilter =
+      environment === 'homolog'
+        ? `AND c.cellphone IN (SELECT phone FROM staging_users)`
+        : '';
 
     // Conta contatos com ao menos 1 chat marcado como test-persona pela EF
     // chat-history-logger. Sem corte por clinic_id — visão unificada.
@@ -1872,6 +1930,7 @@ const getTestContactsCount = async ({ role }) => {
         AND ch.path LIKE 'test-persona|%'
         ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
       )
+      ${envFilter}
       `,
       {
         type: Sequelize.QueryTypes.SELECT,
@@ -1885,8 +1944,13 @@ const getTestContactsCount = async ({ role }) => {
   }
 };
 
-const getB2bContactsCount = async ({ role: _role }) => {
+const getB2bContactsCount = async ({ role: _role, environment = 'prod' }) => {
   try {
+    const envFilter =
+      environment === 'homolog'
+        ? `AND c.cellphone IN (SELECT phone FROM staging_users)`
+        : '';
+
     // Conta contatos cuja cellphone bate com algum clinics.phone_normalized
     // ou clinics.phone. Mesma source do B2B_CONTACT_IDS_SUBQUERY.
     const [result] = await Contact.sequelize.query(
@@ -1898,6 +1962,7 @@ const getB2bContactsCount = async ({ role: _role }) => {
         UNION
         SELECT phone FROM clinics WHERE phone IS NOT NULL
       )
+      ${envFilter}
       `,
       {
         type: Sequelize.QueryTypes.SELECT,

--- a/src/api/repositories/user.repository.js
+++ b/src/api/repositories/user.repository.js
@@ -223,7 +223,7 @@ const getAllAttendants = async ({ clinic_id }) => {
 
 const getUserByEmail = async ({ email, password = false }) => {
   try {
-    const attributes = ['id', 'name', 'email', 'role_id', 'clinic_id', 'created_at'];
+    const attributes = ['id', 'name', 'email', 'role_id', 'clinic_id', 'environment', 'created_at'];
 
     if (password) {
       attributes.push('password');

--- a/src/api/services/auth.service.js
+++ b/src/api/services/auth.service.js
@@ -10,6 +10,10 @@ const generateToken = (user) => {
       role: user?.role,
       clinic: user.clinic,
       clinic_id: user?.clinic?.id,
+      // ADR-0007: ambiente do operador na mensageria. Fallback 'prod' garante
+      // backward compat — tokens emitidos antes da migration (sem campo no DB)
+      // continuam validos e caem no comportamento default.
+      environment: user?.environment || 'prod',
     },
     process.env.JWT_SECRET,
     { expiresIn: '7d' },

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -2,7 +2,20 @@ import ChatRepository from '../repositories/chat-history.repository.js';
 import S3ClientUtil from '../../utils/s3.js';
 import { normalizeQuery } from '../../utils/normalizeQuery.js';
 import { isValidUUID } from '../../utils/validate.js';
+import { isStagingPhone } from '../../utils/staging-users.helper.js';
 import { ChatHistory, Contact } from '../models/index.js';
+
+// ADR-0007 Fatia 7: guard de detail endpoints.
+// Operador em environment=homolog so pode acessar contacts cujo cellphone
+// esta na whitelist staging_users. Pra prod (default), passa sem check.
+// Retorna true se o operador tem permissao de ver o contact em questao.
+const canAccessContactInEnvironment = async (contact, environment) => {
+  if (environment !== 'homolog') return true;
+  if (!contact) return true; // null e' caso "not found", controller responde 404
+  const cellphone = contact.cellphone || contact.dataValues?.cellphone;
+  if (!cellphone) return false; // contact sem phone, blindar acesso em homolog
+  return isStagingPhone(cellphone);
+};
 
 const signMessagesMediaUrls = async (contacts) => {
   for (const contact of contacts) {
@@ -59,6 +72,7 @@ const getAllContactsWithMessages = async ({
   filters = {},
   testFilter = 'exclude',
   b2bFilter = 'exclude',
+  environment = 'prod',
 }) => {
   try {
     const result = await ChatRepository.getAllContactsWithMessages({
@@ -69,6 +83,7 @@ const getAllContactsWithMessages = async ({
       filters,
       testFilter,
       b2bFilter,
+      environment,
     });
     const contacts = result.contacts;
 
@@ -91,6 +106,7 @@ const getAllTestContacts = async ({
   limit = 15,
   user_id,
   filters = {},
+  environment = 'prod',
 }) => {
   return getAllContactsWithMessages({
     role,
@@ -100,6 +116,7 @@ const getAllTestContacts = async ({
     filters,
     testFilter: 'only',
     b2bFilter: 'none',
+    environment,
   });
 };
 
@@ -110,6 +127,7 @@ const getAllB2bContacts = async ({
   limit = 15,
   user_id,
   filters = {},
+  environment = 'prod',
 }) => {
   return getAllContactsWithMessages({
     role,
@@ -119,28 +137,29 @@ const getAllB2bContacts = async ({
     filters,
     testFilter: 'none',
     b2bFilter: 'only',
+    environment,
   });
 };
 
-const getTestContactsCount = async ({ role }) => {
+const getTestContactsCount = async ({ role, environment = 'prod' }) => {
   try {
-    return await ChatRepository.getTestContactsCount({ role });
+    return await ChatRepository.getTestContactsCount({ role, environment });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
 };
 
-const getB2bContactsCount = async ({ role }) => {
+const getB2bContactsCount = async ({ role, environment = 'prod' }) => {
   try {
-    return await ChatRepository.getB2bContactsCount({ role });
+    return await ChatRepository.getB2bContactsCount({ role, environment });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
 };
 
-const getInAttendanceContactsCount = async () => {
+const getInAttendanceContactsCount = async ({ environment = 'prod' } = {}) => {
   try {
-    return await ChatRepository.getInAttendanceContactsCount();
+    return await ChatRepository.getInAttendanceContactsCount({ environment });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
@@ -152,6 +171,7 @@ const getAllContactsBeingAttended = async ({
   limit = 15,
   user_id,
   filters = {},
+  environment = 'prod',
 }) => {
   try {
     const result = await ChatRepository.getAllContactsBeingAttended({
@@ -160,6 +180,7 @@ const getAllContactsBeingAttended = async ({
       limit,
       user_id,
       filters,
+      environment,
     });
     const contacts = result.contacts;
 
@@ -176,7 +197,7 @@ const getAllContactsBeingAttended = async ({
   }
 };
 
-const searchContacts = async ({ query, page, limit, role, user_id, filters = {} }) => {
+const searchContacts = async ({ query, page, limit, role, user_id, filters = {}, environment = 'prod' }) => {
   try {
     const cleanedQuery = normalizeQuery(query);
     const hasLetter = /[a-zA-Z]/.test(cleanedQuery);
@@ -192,6 +213,7 @@ const searchContacts = async ({ query, page, limit, role, user_id, filters = {} 
       role,
       user_id,
       filters,
+      environment,
     });
 
     await attachReplyMessages(contacts);
@@ -210,6 +232,7 @@ const getContactByPetOwnerId = async ({
   limit = 20,
   before = null,
   after = null,
+  environment = 'prod',
 }) => {
   try {
     const result = await ChatRepository.getContactByPetOwnerId({
@@ -222,6 +245,11 @@ const getContactByPetOwnerId = async ({
     });
 
     if (!result.contact) {
+      return null;
+    }
+
+    // ADR-0007 Fatia 7: guard de detail endpoints
+    if (!(await canAccessContactInEnvironment(result.contact, environment))) {
       return null;
     }
 
@@ -242,6 +270,7 @@ const getContactByContactId = async ({
   limit = 20,
   before = null,
   after = null,
+  environment = 'prod',
 }) => {
   try {
     const result = await ChatRepository.getContactByContactId({
@@ -257,6 +286,10 @@ const getContactByContactId = async ({
       return null;
     }
 
+    if (!(await canAccessContactInEnvironment(result.contact, environment))) {
+      return null;
+    }
+
     await attachReplyMessages([result.contact]);
     await signMessagesMediaUrls([result.contact]);
 
@@ -266,16 +299,47 @@ const getContactByContactId = async ({
   }
 };
 
-const getMessagesDaysSummary = async ({ pet_owner_id = null, contact_id = null, role }) => {
+const getMessagesDaysSummary = async ({
+  pet_owner_id = null,
+  contact_id = null,
+  role,
+  environment = 'prod',
+}) => {
   try {
+    // Pra homolog: garantir que pet_owner_id/contact_id pertencem a um contact
+    // staging antes de retornar dias. Caso contrario, retorna lista vazia
+    // (como se nao tivesse mensagens) pra nao vazar metadata.
+    if (environment === 'homolog') {
+      const lookupWhere = contact_id ? { id: contact_id } : { pet_owner_id };
+      const contact = await Contact.findOne({
+        where: lookupWhere,
+        attributes: ['id', 'cellphone'],
+      });
+      if (!(await canAccessContactInEnvironment(contact, environment))) {
+        return { days: [], totalDays: 0, totalMessages: 0 };
+      }
+    }
     return await ChatRepository.getMessagesDaysSummary({ pet_owner_id, contact_id, role });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
 };
 
-const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
+const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10, environment = 'prod' }) => {
   try {
+    // Pra homolog: validar acesso ao contact antes de retornar orders.
+    if (environment === 'homolog') {
+      const contact = await Contact.findOne({
+        where: { id: contact_id },
+        attributes: ['id', 'cellphone'],
+      });
+      if (!(await canAccessContactInEnvironment(contact, environment))) {
+        return {
+          orders: [],
+          pagination: { currentPage: page, limit, totalOrders: 0, hasMore: false, totalPages: 0 },
+        };
+      }
+    }
     return await ChatRepository.getOrdersByContactId({ contact_id, page, limit });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
@@ -288,6 +352,7 @@ const getContactByPetOwnerIdOrPhone = async ({
   role,
   page = 1,
   limit = 20,
+  environment = 'prod',
 }) => {
   try {
     const result = await ChatRepository.getContactByPetOwnerIdOrPhone({
@@ -299,6 +364,10 @@ const getContactByPetOwnerIdOrPhone = async ({
     });
 
     if (!result.contact) {
+      return null;
+    }
+
+    if (!(await canAccessContactInEnvironment(result.contact, environment))) {
       return null;
     }
 

--- a/src/utils/staging-users.helper.js
+++ b/src/utils/staging-users.helper.js
@@ -1,0 +1,65 @@
+// ADR-0007 Fatia 7: cache in-memory da whitelist staging_users.
+//
+// Por que cache:
+//   getStagingPhones() roda em CADA request de mensageria (listing, search,
+//   counts). Sem cache, cada request faz 1 SELECT extra na tabela
+//   staging_users. Cache 30s reduz pra ~1 query/30s sem perder responsividade
+//   pra mudancas na whitelist (operador adiciona phone, ve resultado em <30s).
+//
+// Por que NAO Redis:
+//   Esta lista e pequena (poucas dezenas de phones), muda raramente, e o
+//   custo de coordenar invalidacao via Redis nao vale a pena pra escala
+//   atual do admin web. Re-avaliar se o backend escalar pra multiplas
+//   instancias EC2 (hoje e 1 so).
+//
+// Fallback de erro:
+//   Se a query falhar, retorna o cache stale ou [] como ultimo recurso.
+//   Pra admin prod, [] preserva comportamento atual (sem filtro). Pra admin
+//   homolog, [] retorna lista vazia temporariamente — recupera no proximo
+//   request bem-sucedido.
+
+import { Sequelize } from 'sequelize';
+import { sequelize } from '../config/database.js';
+
+const CACHE_TTL_MS = 30 * 1000;
+
+let cachedPhones = null;
+let cacheExpiresAt = 0;
+
+export async function getStagingPhones() {
+  if (cachedPhones !== null && Date.now() < cacheExpiresAt) {
+    return cachedPhones;
+  }
+  try {
+    const rows = await sequelize.query('SELECT phone FROM staging_users', {
+      type: Sequelize.QueryTypes.SELECT,
+    });
+    cachedPhones = rows.map((r) => r.phone);
+    cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+    return cachedPhones;
+  } catch (err) {
+    console.error('[staging-users] getStagingPhones query failed:', err.message);
+    return cachedPhones ?? [];
+  }
+}
+
+export function invalidateStagingPhonesCache() {
+  cacheExpiresAt = 0;
+  cachedPhones = null;
+}
+
+// Helper pra usar em endpoints de DETAIL (getContactByContactId, etc).
+// Retorna true se o phone esta na whitelist staging.
+export async function isStagingPhone(phone) {
+  if (!phone) return false;
+  const list = await getStagingPhones();
+  return list.includes(phone);
+}
+
+// Retorna 'in' (mostra so staging) quando env=homolog, null (sem filtro)
+// quando env=prod. Centralizar aqui evita branching duplicado nos
+// repositories e mantem o contrato consistente.
+export function buildEnvironmentFilter(environment) {
+  if (environment === 'homolog') return { op: 'in' };
+  return null;
+}


### PR DESCRIPTION
## Summary

- Backend Fatia 7 do ADR-0007 (staging strategy): filtro server-side da mensageria por `users.environment` + whitelist `staging_users`
- Conta `homolog@latta.com.br` (a ser criada) ve APENAS contacts em `staging_users`. Conta prod (todos existentes) ve comportamento atual intocado
- Helper centralizado com cache 30s pra reduzir overhead
- Bonus: conserta bug pre-existente em `getAllContactsBeingAttended` (`b2bFilter` nao destructurado)

## Mudancas

**Helper novo:**
- `src/utils/staging-users.helper.js`: `getStagingPhones()` com cache in-memory 30s, fallback seguro pra cache stale ou `[]` em erro de query, `isStagingPhone()`, `buildEnvironmentFilter()`

**Auth + Model:**
- `UserModel.js`: coluna `environment` (STRING 16, default `'prod'`, validate `isIn: [['prod', 'homolog']]`)
- `user.repository.getUserByEmail`: select `environment`
- `auth.service.generateToken`: JWT payload ganha `environment` (fallback `'prod'`)

**Mensageria:**
- `chat-history.repository.js`: `STAGING_CONTACT_IDS_SUBQUERY` + `buildStagingEnvironmentCondition`. Parametro `environment` em 6 metodos: 3 listings (`getAllContactsWithMessages`, `getAllContactsBeingAttended`, `searchContacts`) + 3 counts (`getInAttendanceContactsCount`, `getTestContactsCount`, `getB2bContactsCount`)
- `chat-history.service.js`: pass-through `environment` em todos metodos + guard `canAccessContactInEnvironment` nos 5 detail endpoints (`getContactByContactId`, `getContactByPetOwnerId`, `getContactByPetOwnerIdOrPhone`, `getOrdersByContactId`, `getMessagesDaysSummary`)
- `chat-history.controller.js`: extrai `req.user.environment` e propaga pro service em 12 endpoints

## Backward compat

- Users existentes recebem `environment='prod'` via DEFAULT da migration
- JWT antigos (sem campo) → middleware faz fallback `\|\| 'prod'` em todos endpoints
- `buildStagingEnvironmentCondition` retorna `null` quando `environment !== 'homolog'` → query original passa intocada
- Counts: `envFilter` e string vazia quando prod → SQL identico
- Guard retorna `true` quando prod → sem 404 indevido

## Bug fix bonus

`getAllContactsBeingAttended` antes nao destructurava `b2bFilter` na assinatura mas referenciava `buildB2bChatFilter(b2bFilter)` — ReferenceError silencioso. Agora corrigido com `b2bFilter = 'exclude'` na assinatura.

## Dependencias

- Migration aplicada via PR Matheus3FY/Latta#515 ANTES do deploy desse backend
- Frontend correspondente: Latta-app/frontend (PR a criar)

## Test plan

- [ ] Login com user existente continua funcionando (JWT antigo, sem environment, cai em fallback)
- [ ] Admin prod: aba "Geral" mostra mesma lista de antes (sem regressao)
- [ ] Admin prod: aba "Testes" continua funcional
- [ ] Admin prod: aba "B2B" continua funcional
- [ ] Apos criar `homolog@latta.com.br` (environment='homolog') + popular `staging_users`: login retorna `environment` no user; mensageria mostra APENAS contacts em `staging_users`
- [ ] Detail endpoint pra contact fora de `staging_users` retorna 404 quando logado como homolog
- [ ] Cache 30s funciona: alterar staging_users via SQL, esperar 30s, ver refletido

🤖 Generated with [Claude Code](https://claude.com/claude-code)