### PR TITLE
fix(mensageria): homolog override testFilter/b2bFilter default 'exclude'

### DIFF
--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -17,6 +17,23 @@ const canAccessContactInEnvironment = async (contact, environment) => {
   return isStagingPhone(cellphone);
 };
 
+// ADR-0007 Fatia 7: em environment=homolog, o filtro de staging_users ja
+// cobre o universo visivel. Os filtros testFilter/b2bFilter padroes ('exclude')
+// colidem com staging_users quando phones do range test personas
+// (5500000000XXX) estao na whitelist — o `id NOT IN (TEST_CONTACT_IDS)`
+// derruba TODOS os contacts de staging.
+// Solucao: pra homolog, neutralizar testFilter/b2bFilter ('none') a menos
+// que o caller tenha pedido explicitamente um valor diferente do default.
+const resolveTestB2bFiltersForEnvironment = (environment, testFilter, b2bFilter) => {
+  if (environment !== 'homolog') {
+    return { testFilter, b2bFilter };
+  }
+  return {
+    testFilter: testFilter === 'exclude' ? 'none' : testFilter,
+    b2bFilter: b2bFilter === 'exclude' ? 'none' : b2bFilter,
+  };
+};
+
 const signMessagesMediaUrls = async (contacts) => {
   for (const contact of contacts) {
     const chatHistory = contact.dataValues?.chatHistory || [];
@@ -75,14 +92,15 @@ const getAllContactsWithMessages = async ({
   environment = 'prod',
 }) => {
   try {
+    const filtersForEnv = resolveTestB2bFiltersForEnvironment(environment, testFilter, b2bFilter);
     const result = await ChatRepository.getAllContactsWithMessages({
       role,
       page,
       limit,
       user_id,
       filters,
-      testFilter,
-      b2bFilter,
+      testFilter: filtersForEnv.testFilter,
+      b2bFilter: filtersForEnv.b2bFilter,
       environment,
     });
     const contacts = result.contacts;
@@ -171,15 +189,20 @@ const getAllContactsBeingAttended = async ({
   limit = 15,
   user_id,
   filters = {},
+  testFilter = 'exclude',
+  b2bFilter = 'exclude',
   environment = 'prod',
 }) => {
   try {
+    const filtersForEnv = resolveTestB2bFiltersForEnvironment(environment, testFilter, b2bFilter);
     const result = await ChatRepository.getAllContactsBeingAttended({
       role,
       page,
       limit,
       user_id,
       filters,
+      testFilter: filtersForEnv.testFilter,
+      b2bFilter: filtersForEnv.b2bFilter,
       environment,
     });
     const contacts = result.contacts;


### PR DESCRIPTION
## Bug

Smoke test fim-a-fim depois do deploy do PR #65 mostrou que admin homolog (\`homolog@latta.com.br\`) recebia **0 contacts** da mensageria, mesmo com 52 phones em \`staging_users\`.

### Causa raiz

O seed inicial da migration \`20260531000000_staging_environment_and_users.sql\` inseriu na whitelist os mesmos phones que ja eram filtrados como \`TEST_CONTACT_IDS_SUBQUERY\` (range \`5500000000XXX\`). A query do listing aplicava ambos filtros em AND:
  - \`id IN (staging_users)\` ✅ inclui 52 phones
  - \`id NOT IN (test_personas)\` ❌ exclui MESMOS 52 phones
  - Resultado: **0 contacts**

### Fix

Helper \`resolveTestB2bFiltersForEnvironment\` neutraliza \`testFilter\` e \`b2bFilter\` default (\`'exclude'\`) pra \`'none'\` quando \`environment='homolog'\`. Pra prod (default), zero mudanca.

Pra environment='homolog' explicitamente:
  - default \`testFilter='exclude'\` → vira \`'none'\` (sem filtro)
  - default \`b2bFilter='exclude'\` → vira \`'none'\`
  - Caller que pediu \`'only'\` explicitamente (ex: getAllTestContacts) mantem o valor

Aplicado em:
  - \`getAllContactsWithMessages\`
  - \`getAllContactsBeingAttended\`

\`searchContacts\` nao precisa: nao cruza com \`TEST_CONTACT_IDS_SUBQUERY\`/\`B2B_CONTACT_IDS_SUBQUERY\` no repository.

## Test plan

- [x] Validacao SQL: \`SELECT COUNT(*) FROM contacts WHERE id IN (staging_users)\` retorna 52
- [x] Login homolog: JWT contem environment='homolog'
- [ ] Pos-deploy: \`GET /api/chat-history/messages/getAllContactsWithMessages\` com token homolog retorna ~52 contacts (validar)
- [ ] Admin prod continua retornando todos contacts (sem regressao)

🤖 Generated with [Claude Code](https://claude.com/claude-code)