### PR TITLE
fix(admin): prod exclui universo QA (whitelist + test), homolog mostra ambos

### DIFF
--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -63,17 +63,33 @@ const STAGING_CONTACT_IDS_SUBQUERY = `(
   WHERE c.cellphone IN (SELECT phone FROM staging_users)
 )`;
 
-// Retorna a condicao Sequelize adequada pra adicionar em additionalConditions,
-// ou null pra deixar a query passar sem filtro de environment. Pra prod
-// (default), retorna null — preserva comportamento existente. Pra homolog,
-// retorna { id: { [Op.in]: STAGING_CONTACT_IDS_SUBQUERY } }.
+// Universo QA = whitelist (staging_users) UNION test personas (marcador
+// test-persona| no path OU cellphone do range 5500000000XXX). ADR-0007 Fatia 7
+// (refinado 2026-06-02): test + whitelist vivem SO no homolog; o prod nao
+// mostra nenhum dos dois (aba "Testes" do prod foi removida). Sem a uniao,
+// test personas que nao estao na whitelist (ex: usados em smoke) ficariam
+// orfaos — invisiveis no prod (excluidos) e no homolog (nao-whitelist).
+const QA_CONTACT_IDS_SUBQUERY = `(
+  SELECT c.id FROM contacts c WHERE c.cellphone IN (SELECT phone FROM staging_users)
+  UNION
+  SELECT DISTINCT ch.contact_id FROM chat_history ch
+  WHERE ch.path LIKE 'test-persona|%' AND ch.contact_id IS NOT NULL
+  UNION
+  SELECT c.id FROM contacts c WHERE c.cellphone ~ '^5500000000[0-9]{3}$'
+)`;
+
+// Filtro de environment (ADR-0007 Fatia 7 + refino 2026-06-02):
+//   - homolog: mostra APENAS o universo QA (whitelist ∪ test personas)
+//   - prod:    EXCLUI todo o universo QA (operador ve so cliente real).
+// Antes o prod retornava null (sem filtro) — o que vazava whitelist (ex: Lucas)
+// pro admin principal. Agora e o espelho exato do homolog. Dinamico via
+// staging_users (cache 30s no helper) — sai/entra da whitelist reflete sem
+// marcar nada por contato.
 const buildStagingEnvironmentCondition = (Op, environment) => {
-  if (environment !== 'homolog') return null;
-  return {
-    id: {
-      [Op.in]: Sequelize.literal(STAGING_CONTACT_IDS_SUBQUERY),
-    },
-  };
+  if (environment === 'homolog') {
+    return { id: { [Op.in]: Sequelize.literal(QA_CONTACT_IDS_SUBQUERY) } };
+  }
+  return { id: { [Op.notIn]: Sequelize.literal(QA_CONTACT_IDS_SUBQUERY) } };
 };
 
 const RECENT_ORDERS_LIMIT = 10;


### PR DESCRIPTION
## Bug
`buildStagingEnvironmentCondition` retornava `null` pra **prod** (sem filtro) → phones da whitelist `staging_users` (ex: Lucas) **vazavam pro admin principal**, aparecendo nas duas mensagerias. Diverge do ADR-0007 D9 (que previa `notIn` no prod).

## Fix
- **`QA_CONTACT_IDS_SUBQUERY`** = `staging_users` ∪ test-marker (`path LIKE 'test-persona|%'` OU `cellphone ~ '^5500000000[0-9]{3}$'`).
- **homolog** → `id IN (QA)`: whitelist + **todos** os test personas (fecha o buraco de test personas fora da whitelist ficarem órfãos quando a aba Testes do prod sair).
- **prod** → `id NOT IN (QA)`: espelho exato — operador só vê cliente real.

Aplicado nas 3 listagens: `getAllContactsWithMessages`, `getAllContactsBeingAttended` (Luma), `searchContacts`. Dinâmico via `staging_users` (cache 30s) — `staging:remove` reflete em <30s.

## Pareado com
Remoção da aba **"Testes"** do prod no frontend (Latta-app/frontend) — test + whitelist passam a viver só no homolog.

## Deploy
Auto-deploy EC2 no merge. Validação pós-deploy: Lucas (whitelist) some do admin principal e segue no homolog; test personas só no homolog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)