### PR TITLE
fix(socket): isola new_message por ambiente (homolog vs prod) — ADR-0007 D9

### DIFF
--- a/src/api/routes/socket/socketRoutes.js
+++ b/src/api/routes/socket/socketRoutes.js
@@ -2,7 +2,8 @@ import express from 'express';
 import S3ClientUtil from '../../../utils/s3.js';
 import ChatRepository from '../../repositories/chat-history.repository.js';
 import { isValidUUID } from '../../../utils/validate.js';
-import { MESSAGING_ROOM } from '../../../config/socket.js';
+import { MESSAGING_ROOM, messagingEnvRoom } from '../../../config/socket.js';
+import { isQaPhone } from '../../../utils/staging-users.helper.js';
 
 // Função para assinar URLs de mídia
 const signMessageMediaUrl = async (messageData) => {
@@ -129,22 +130,34 @@ function createSocketRoutes(io) {
       messageData = await signMessageMediaUrl(messageData);
       messageData = await attachReplyMessage(messageData);
 
-      // Visão unificada (refactor 2026-05-08): emite pra sala global única.
-      // Todos os usuários autenticados recebem todas as mensagens.
-      const room = io.sockets.adapter.rooms.get(MESSAGING_ROOM);
+      // ADR-0007 Fatia 7 (fix 2026-06-04): roteia o push pela sala do ambiente.
+      // QA (whitelist staging_users OU range test-persona) -> painel homolog;
+      // cliente real -> painel prod. Espelha o filtro da listagem REST, que
+      // antes divergia do socket (broadcast global vazava QA<->prod ao vivo,
+      // ate dar F5). Fallback: sem cell_phone, mantem broadcast global (raro —
+      // toda chat_history tem cell_phone; nao arriscar sumir msg de um painel).
+      let targetRoom = MESSAGING_ROOM;
+      if (cell_phone) {
+        const targetEnv = (await isQaPhone(cell_phone)) ? 'homolog' : 'prod';
+        targetRoom = messagingEnvRoom(targetEnv);
+      } else {
+        console.warn('⚠️ new_message sem cell_phone — broadcast global (fallback)');
+      }
+
+      const room = io.sockets.adapter.rooms.get(targetRoom);
       console.log(
         room
-          ? `✅ Sala '${MESSAGING_ROOM}' com ${room.size} sockets`
-          : `❌ Sala '${MESSAGING_ROOM}' vazia`,
+          ? `✅ Sala '${targetRoom}' com ${room.size} sockets`
+          : `❌ Sala '${targetRoom}' vazia`,
       );
 
-      io.to(MESSAGING_ROOM).emit('new_message', messageData);
-      console.log(`📤 new_message emitido para '${MESSAGING_ROOM}'`);
+      io.to(targetRoom).emit('new_message', messageData);
+      console.log(`📤 new_message emitido para '${targetRoom}' (phone=${cell_phone || 'n/a'})`);
 
       res.json({
         success: true,
         sent: true,
-        room: MESSAGING_ROOM,
+        room: targetRoom,
       });
 
       console.log('✅ Webhook finalizado com sucesso');

--- a/src/config/socket.js
+++ b/src/config/socket.js
@@ -6,6 +6,16 @@ import jwt from 'jsonwebtoken';
 // Se voltar multi-clinic no futuro, reintroduzir clinic-specific rooms.
 const MESSAGING_ROOM = 'messaging_global';
 
+// ADR-0007 Fatia 7 (fix 2026-06-04): salas separadas por ambiente pro push em
+// tempo real. A listagem REST ja filtrava por environment (homolog=universo QA,
+// prod=cliente real), mas o socket new_message era broadcast pra MESSAGING_ROOM
+// global — entao msg de QA vazava pro painel prod e vice-versa, ate dar F5.
+// Cada socket entra na sala do seu environment; o emissor roteia a msg pela
+// classificacao QA do telefone (isQaPhone). MESSAGING_ROOM continua existindo
+// so pros eventos de presenca (attendant_connected/disconnected).
+const messagingEnvRoom = (environment) =>
+  environment === 'homolog' ? 'messaging:homolog' : 'messaging:prod';
+
 const userLastSeen = new Map();
 const userSockets = new Map();
 
@@ -88,7 +98,13 @@ function initializeSocket(httpServer) {
     userSockets.set(userId, socket.id);
 
     socket.join(MESSAGING_ROOM);
-    console.log(`✅ Usuário ${userName} adicionado à sala '${MESSAGING_ROOM}'`);
+    // Sala por ambiente: new_message e' roteado pra ca' (homolog vs prod),
+    // espelhando o filtro da listagem REST. environment vem do JWT (socket.user).
+    const envRoom = messagingEnvRoom(socket.user?.environment);
+    socket.join(envRoom);
+    console.log(
+      `✅ Usuário ${userName} nas salas '${MESSAGING_ROOM}' + '${envRoom}'`,
+    );
 
     // Notifica os outros conectados
     socket.to(MESSAGING_ROOM).emit('attendant_connected', {
@@ -213,4 +229,4 @@ function initializeSocket(httpServer) {
   return { io, MESSAGING_ROOM };
 }
 
-export { initializeSocket, MESSAGING_ROOM };
+export { initializeSocket, MESSAGING_ROOM, messagingEnvRoom };

--- a/src/utils/staging-users.helper.js
+++ b/src/utils/staging-users.helper.js
@@ -63,3 +63,33 @@ export function buildEnvironmentFilter(environment) {
   if (environment === 'homolog') return { op: 'in' };
   return null;
 }
+
+// Normaliza phone BR pro formato canonico 13-dig (55 + DDD + 9 + 8 digitos).
+// Espelha normalizeBrPhone da EF chat-history-logger pra garantir match
+// consistente com staging_users (que guarda 13-dig). Sem isso, um payload
+// que chegue em 12-dig (sem o 9o digito) nao casaria a whitelist.
+function normalizeBrPhone(raw) {
+  const digits = String(raw || '').replace(/\D/g, '');
+  if (digits.length === 12 && digits.startsWith('55')) {
+    return `${digits.slice(0, 4)}9${digits.slice(4)}`;
+  }
+  return digits;
+}
+
+const TEST_PERSONA_RANGE_RE = /^5500000000\d{3}$/;
+
+// Universo QA = whitelist (staging_users) OU range de test personas
+// (5500000000XXX). Espelha o QA_CONTACT_IDS_SUBQUERY do repository (ADR-0007
+// Fatia 7): o arm `path LIKE 'test-persona|%'` e' subconjunto do range
+// (o marcador test-persona so e' gravado pra phones desse range pela EF
+// chat-history-logger), entao checar range + whitelist cobre o mesmo universo.
+// Usado pelo push em tempo real (socket new_message) pra rotear msg de QA so
+// pro painel homolog e msg de cliente real so pro prod — espelhando o filtro
+// da listagem REST, que antes divergia (socket era broadcast global).
+export async function isQaPhone(phone) {
+  const norm = normalizeBrPhone(phone);
+  if (!norm) return false;
+  if (TEST_PERSONA_RANGE_RE.test(norm)) return true;
+  const list = await getStagingPhones();
+  return list.includes(norm);
+}


### PR DESCRIPTION
## Problema (reportado pelo Lucas, validado ao vivo)

No admin de mensageria, contatos vazavam entre ambientes **em tempo real**:
- **Lucas** (na whitelist `staging_users`) aparecia no painel **principal/prod**.
- **Íris** (cliente real, fora da whitelist) aparecia no painel **homolog**.

Um **F5 corrigia** — por isso parecia intermitente.

## Causa-raiz

Há duas camadas e só uma filtrava por `environment`:

| Camada | Filtra por ambiente? |
|---|---|
| Listagem REST (`getAllContactsWithMessages`) | ✅ sim (`id IN/NOT IN` universo QA) |
| Push tempo-real (socket `new_message`) | ❌ **não** — broadcast pra `MESSAGING_ROOM` global |

O refactor "visão unificada" do socket (2026-05-08) é **anterior** ao D9 (Fatia 7, 31/05). Quando o D9 filtrou a REST, o socket ficou pra trás → toda `new_message` ia pros dois painéis ao vivo; só o refresh (REST) corrigia.

## Fix (server-side, espelha a REST)

- **`socket.js`**: cada socket entra numa sala por ambiente (`messaging:homolog` | `messaging:prod`) lida do `environment` do JWT. `MESSAGING_ROOM` global segue só pros eventos de presença (`attendant_connected/disconnected`).
- **`socketRoutes.js`**: `new_message` é roteado pela classificação QA do telefone do contato → só pra sala do ambiente certo. Fallback pro global se faltar `cell_phone` (raro — toda `chat_history` tem `cell_phone`).
- **`staging-users.helper.js`**: novo `isQaPhone(phone)` = whitelist (`staging_users`) **OU** range test-persona (`5500000000XXX`), com `normalizeBrPhone` (12→13 díg). Espelha o `QA_CONTACT_IDS_SUBQUERY` da REST (o arm `path LIKE 'test-persona|%'` é subconjunto do range).

## Validação

`node --check` OK nos 3 arquivos. Teste de `isQaPhone` contra o DB real:

| Telefone | Caso | Esperado | Resultado |
|---|---|---|---|
| 5531991927909 | Lucas (whitelist) | homolog | ✅ true |
| 5531999155797 | Íris (real) | prod | ✅ false |
| 5500000000001 | Persona seedada (range) | homolog | ✅ true |
| 5500000088001 | Tutor Teste e2e (não-QA) | prod | ✅ false |
| 553191927909 | Lucas 12-díg (normalização) | homolog | ✅ true |

## Notas
- Sem mudança no frontend (já escuta `new_message`; agora só recebe da sala do seu ambiente).
- `/test-socket` (endpoint manual) segue no global — é só ferramenta de teste.
- Merge na `main` dispara auto-deploy pra EC2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)