### PR TITLE
feat(backend): worker Petz OTP quick-access all-in-browser (caminho B)

### DIFF
--- a/src/api/controllers/petz-otp.controller.js
+++ b/src/api/controllers/petz-otp.controller.js
@@ -1,0 +1,99 @@
+// Controller do fluxo Petz OTP quick-access (caminho B). A sessão Browserbase
+// fica viva no worker entre `start` (access+send) e `verify` (submit do código),
+// guardada em `otpSessions` por sessionId. Espelha o padrão de web-scarpping.controller.
+
+import path from 'path';
+import { fork } from 'child_process';
+import crypto from 'crypto';
+
+const otpSessions = new Map(); // sessionId -> { worker, createdAt }
+const SESSION_TTL_MS = 5 * 60 * 1000;
+
+const sidFor = (cpf) => crypto.createHash('md5').update(String(cpf)).digest('hex');
+
+function reapExpired() {
+  const now = Date.now();
+  for (const [sid, s] of otpSessions.entries()) {
+    if (now - s.createdAt > SESSION_TTL_MS) {
+      try { s.worker.kill('SIGKILL'); } catch { /* ok */ }
+      otpSessions.delete(sid);
+    }
+  }
+}
+
+// POST /web-scrapping/petz/otp/start  { cpf, channel?: 'SMS'|'WPP' }
+// -> { success, sessionId, exists, maskedPhone, hasWppRetry, sendStatus }
+const petzOtpStart = async (req, res) => {
+  reapExpired();
+  const { cpf, channel = 'SMS' } = req.body || {};
+  if (!cpf) return res.status(400).json({ code: 'INVALID_DATA', message: 'cpf é obrigatório' });
+
+  const sessionId = sidFor(cpf);
+  // se já existe sessão viva pra esse cpf, encerra antes de abrir nova
+  const prev = otpSessions.get(sessionId);
+  if (prev) { try { prev.worker.kill('SIGKILL'); } catch { /* ok */ } otpSessions.delete(sessionId); }
+
+  const workerPath = path.resolve('src/api/workers/petz-otp-runner.js');
+  const child = fork(workerPath, [JSON.stringify({ cpf, channel, sessionId })], {
+    silent: true, stdio: ['pipe', 'pipe', 'pipe', 'ipc'], execArgv: [],
+  });
+  child.stdout.on('data', (d) => process.stdout.write(`[otp-worker] ${d}`));
+  child.stderr.on('data', (d) => process.stderr.write(`[otp-worker-err] ${d}`));
+
+  try {
+    const startResult = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* ok */ } reject(new Error('TIMEOUT')); }, 90 * 1000);
+      child.once('message', (msg) => {
+        clearTimeout(timeout);
+        if (msg?.status === 'awaiting_code') resolve(msg);
+        else reject(new Error(msg?.message || 'falha no start'));
+      });
+      child.on('exit', (code) => { if (code !== 0) reject(new Error(`worker saiu (${code})`)); });
+    });
+
+    otpSessions.set(sessionId, { worker: child, createdAt: Date.now() });
+    return res.status(200).json({
+      success: true,
+      sessionId,
+      exists: startResult.exists,
+      maskedPhone: startResult.maskedPhone,
+      hasWppRetry: startResult.hasWppRetry,
+      sendStatus: startResult.sendStatus,
+    });
+  } catch (err) {
+    try { child.kill('SIGKILL'); } catch { /* ok */ }
+    const code = err.message === 'TIMEOUT' ? 504 : 500;
+    return res.status(code).json({ code: 'OTP_START_ERROR', message: err.message });
+  }
+};
+
+// POST /web-scrapping/petz/otp/verify  { sessionId | cpf, code }
+// -> { success, cookies } | { success:false, code:'INVALID_CODE' }
+const petzOtpVerify = async (req, res) => {
+  reapExpired();
+  const { code } = req.body || {};
+  const sessionId = req.body?.sessionId || (req.body?.cpf ? sidFor(req.body.cpf) : null);
+  if (!sessionId || !code) return res.status(400).json({ code: 'INVALID_DATA', message: 'sessionId (ou cpf) e code são obrigatórios' });
+
+  const session = otpSessions.get(sessionId);
+  if (!session) return res.status(410).json({ code: 'SESSION_EXPIRED', message: 'sessão OTP expirou — reenvie o código' });
+
+  try {
+    const result = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('VERIFY_TIMEOUT')), 60 * 1000);
+      session.worker.once('message', (msg) => { clearTimeout(timeout); resolve(msg); });
+      session.worker.on('exit', (c) => { if (c !== 0) reject(new Error(`worker saiu (${c})`)); });
+      session.worker.send({ action: 'submit_code', code });
+    });
+
+    otpSessions.delete(sessionId); // worker se encerra após o verify
+    if (result?.status === 'success') return res.status(200).json({ success: true, cookies: result.cookies });
+    if (result?.status === 'invalid_code') return res.status(401).json({ success: false, code: 'INVALID_CODE', message: 'código inválido ou expirado' });
+    return res.status(500).json({ success: false, code: 'OTP_VERIFY_ERROR', message: result?.message || 'falha no verify' });
+  } catch (err) {
+    otpSessions.delete(sessionId);
+    return res.status(500).json({ success: false, code: 'OTP_VERIFY_ERROR', message: err.message });
+  }
+};
+
+export default { petzOtpStart, petzOtpVerify };

--- a/src/api/controllers/petz-otp.controller.js
+++ b/src/api/controllers/petz-otp.controller.js
@@ -87,7 +87,16 @@ const petzOtpVerify = async (req, res) => {
     });
 
     otpSessions.delete(sessionId); // worker se encerra após o verify
-    if (result?.status === 'success') return res.status(200).json({ success: true, cookies: result.cookies });
+    if (result?.status === 'success') {
+      return res.status(200).json({
+        success: true,
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        petzClientId: result.petzClientId,
+        deviceId: result.deviceId,
+      });
+    }
     if (result?.status === 'invalid_code') return res.status(401).json({ success: false, code: 'INVALID_CODE', message: 'código inválido ou expirado' });
     return res.status(500).json({ success: false, code: 'OTP_VERIFY_ERROR', message: result?.message || 'falha no verify' });
   } catch (err) {

--- a/src/api/routes/private/web-scrapping.route.js
+++ b/src/api/routes/private/web-scrapping.route.js
@@ -1,10 +1,15 @@
 import { Router } from 'express';
 import WebScrappingController from '../../controllers/web-scarpping.controller.js';
+import PetzOtpController from '../../controllers/petz-otp.controller.js';
 
 const router = Router();
 
 router.post('/login-petz', WebScrappingController.loginPetz);
 router.post('/petz/sms', WebScrappingController.submitSmsCode);
 router.post('/login-cobasi', WebScrappingController.loginCobasi);
+
+// Petz OTP quick-access (caminho B do connect-or-create — all-in-browser)
+router.post('/petz/otp/start', PetzOtpController.petzOtpStart);
+router.post('/petz/otp/verify', PetzOtpController.petzOtpVerify);
 
 export default router;

--- a/src/api/services/petz-otp.service.js
+++ b/src/api/services/petz-otp.service.js
@@ -1,0 +1,126 @@
+// Petz OTP "quick-access" all-in-browser (caminho B de petz-connect-mandatory-onboarding).
+//
+// Diferente do login por senha (web-scrapping.service.js), este fluxo é o
+// passwordless OTP da Petz, usado pra CONECTAR conta existente no onboarding:
+//   1) /access            -> número CADASTRADO mascarado (diligência Q1)
+//   2) otp send (SMS|WPP)  -> envia o código (WhatsApp imediato)
+//   3) auth verify          -> valida o código e conecta
+//
+// TUDO dentro do Browserbase (stealth vence o Akamai; o IP do Browserbase passa).
+// Não usamos chamadas cruas da EF porque o Akamai exige egress consistente e o
+// Browserbase não roteia external proxy nesta conta (ver issue §11, caminho A
+// bloqueado). A sessão fica VIVA entre o send e o verify (keepAlive), igual ao
+// login runner — o tutor manda o código no chat e a gente verifica na mesma sessão.
+//
+// Endpoints validados 2026-06-05 (issue §2):
+//   POST /api/v3/public/client/access     {cpf, tipoToken}
+//   POST /api/v4/otp/public/quick-access  {identifier, contactMethod: 'SMS'|'WPP'}
+//   POST /api/v4/auth/quick-access        {customerKey, accessCode}
+
+import 'dotenv/config';
+import { Stagehand } from '@browserbasehq/stagehand';
+
+const PETZ_BASE = 'https://www.petz.com.br';
+const LOGIN_URL = `${PETZ_BASE}/checkout/login/indexLogado_Loja`;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function newStagehand() {
+  const useCloud = process.env.USE_BROWSERBASE === 'true';
+  return new Stagehand({
+    env: useCloud ? 'BROWSERBASE' : 'LOCAL',
+    apiKey: process.env.BROWSERBASE_API_KEY,
+    projectId: process.env.BROWSERBASE_PROJECT_ID,
+    enableCaching: false,
+    ...(useCloud
+      ? { browserbaseSessionCreateParams: { keepAlive: true, timeout: 300 } }
+      : {
+          localBrowserLaunchOptions: {
+            headless: true,
+            ...(process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : {}),
+            args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--lang=pt-BR'],
+          },
+        }),
+  });
+}
+
+// fetch in-browser (passa pelo contexto Akamai-válido da sessão já aquecida)
+async function browserPost(page, path, body) {
+  return page.evaluate(async ({ path, body }) => {
+    const r = await fetch(path, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json; charset=UTF-8', versionapi: '3' },
+      body: JSON.stringify(body),
+    });
+    let data = null;
+    try { data = await r.json(); } catch { /* corpo pode não ser JSON */ }
+    return { status: r.status, data };
+  }, { path, body });
+}
+
+/**
+ * Abre a sessão, identifica a conta (masked) e ENVIA o código pelo canal pedido.
+ * Mantém a sessão VIVA (retorna stagehand+page) pro verify subsequente.
+ * @returns {Promise<{stagehand,page,exists,maskedPhone,hasWppRetry,sendStatus}>}
+ */
+export async function startPetzOtp({ cpf, channel = 'SMS' }) {
+  const stagehand = newStagehand();
+  await stagehand.init();
+  const page = stagehand.page;
+  try {
+    await page.goto(LOGIN_URL, { waitUntil: 'networkidle', timeout: 90000 });
+    await sleep(2500);
+
+    // 1) abre o modal de acesso rápido + dispara o /access da PRÓPRIA página
+    //    (aquece o sensor Akamai e devolve o número mascarado)
+    await page.click('text=Receber código de acesso rápido', { timeout: 15000 });
+    await sleep(1500);
+    await page.evaluate((c) => {
+      const i = [...document.querySelectorAll('input')].find(
+        (x) => x.offsetParent !== null && x.type !== 'password' && x.id !== 'loginEmail',
+      );
+      if (i) { i.focus(); i.value = c; i.dispatchEvent(new Event('input', { bubbles: true })); i.dispatchEvent(new Event('change', { bubbles: true })); }
+    }, cpf);
+    await sleep(600);
+    const [accessResp] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/v3/public/client/access'), { timeout: 20000 }).catch(() => null),
+      page.click('text=Continuar', { timeout: 10000 }),
+    ]);
+    let exists = false, maskedPhone = null, hasWppRetry = false;
+    if (accessResp && accessResp.status() === 200) {
+      const body = await accessResp.json().catch(() => null);
+      const ca = body?.result?.clientAccess;
+      exists = !!ca;
+      maskedPhone = ca?.cellphone ?? null;
+      hasWppRetry = !!ca?.hasWppRetry;
+    }
+    await sleep(500);
+
+    // 2) envia o código pelo canal (sessão já aquecida → fetch in-browser passa)
+    const send = await browserPost(page, '/api/v4/otp/public/quick-access', {
+      identifier: cpf,
+      contactMethod: channel === 'WPP' ? 'WPP' : 'SMS',
+    });
+
+    return { stagehand, page, exists, maskedPhone, hasWppRetry, sendStatus: send.status };
+  } catch (err) {
+    await stagehand.close().catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * Verifica o código NA MESMA sessão viva do startPetzOtp.
+ * @returns {Promise<{success:boolean,status:number,cookies?:string,data:unknown}>}
+ */
+export async function verifyPetzOtp({ page, cpf, code }) {
+  const res = await browserPost(page, '/api/v4/auth/quick-access', { customerKey: cpf, accessCode: code });
+  let cookies;
+  if (res.status === 200) {
+    cookies = JSON.stringify(await page.context().cookies().catch(() => []));
+  }
+  return { success: res.status === 200, status: res.status, cookies, data: res.data };
+}
+
+export async function closePetzOtp(stagehand) {
+  try { await stagehand?.close(); } catch { /* ok */ }
+}

--- a/src/api/services/petz-otp.service.js
+++ b/src/api/services/petz-otp.service.js
@@ -109,16 +109,68 @@ export async function startPetzOtp({ cpf, channel = 'SMS' }) {
 }
 
 /**
- * Verifica o código NA MESMA sessão viva do startPetzOtp.
- * @returns {Promise<{success:boolean,status:number,cookies?:string,data:unknown}>}
+ * Verifica o código NA MESMA sessão viva do startPetzOtp e reconcilia os tokens
+ * que o cart/checkout usam. Protocolo validado 2026-06-05/10 (ver issue
+ * petz-connect-mandatory-onboarding/SMOKE-VALIDATED-2026-06-10.md):
+ *   1) POST /api/v4/auth/quick-access {customerKey, accessCode}
+ *      headers: X-Use-Otp-Validation:true + Device-Id (cookie device_id)
+ *      -> 200 {access_token, refresh_token, expires_in}
+ *   2) GET /api/v3/client/get_by_token
+ *      headers: X-Authorization: Bearer <access_token> + Authorization Basic (app) + Device-Id
+ *      -> result.client.id = petz_client_id
+ * O header X-Use-Otp-Validation é OBRIGATÓRIO no verify — sem ele o endpoint
+ * retorna 401 "Código não encontrado".
+ * @returns {Promise<{success:boolean,status:number,accessToken?:string,refreshToken?:string,expiresIn?:number,petzClientId?:string,deviceId?:string,data:unknown}>}
  */
 export async function verifyPetzOtp({ page, cpf, code }) {
-  const res = await browserPost(page, '/api/v4/auth/quick-access', { customerKey: cpf, accessCode: code });
-  let cookies;
-  if (res.status === 200) {
-    cookies = JSON.stringify(await page.context().cookies().catch(() => []));
+  const out = await page.evaluate(async ({ cpf, code }) => {
+    const deviceId = (document.cookie.match(/(?:^|;\s*)device_id=([^;]+)/) || [])[1] || '';
+    // 1) verify
+    const vr = await fetch('/api/v4/auth/quick-access', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json; charset=UTF-8',
+        'X-Use-Otp-Validation': 'true',
+        'Device-Id': deviceId,
+      },
+      body: JSON.stringify({ customerKey: cpf, accessCode: code }),
+    });
+    let vdata = null;
+    try { vdata = await vr.json(); } catch { /* ok */ }
+    if (vr.status !== 200 || !vdata?.access_token) {
+      return { status: vr.status, data: vdata, deviceId };
+    }
+    // 2) client id via token (mesmo Bearer que o cart usa)
+    let petzClientId = null;
+    try {
+      const cr = await fetch('/api/v3/client/get_by_token', {
+        headers: {
+          'X-Authorization': `Bearer ${vdata.access_token}`,
+          Authorization: 'Basic cGV0ejpwZXR6MTAxMA==',
+          'Device-Id': deviceId,
+          'content-type': 'application/json; charset=UTF-8',
+        },
+      });
+      const cdata = await cr.json().catch(() => null);
+      const client = cdata?.result?.client || cdata?.client || null;
+      if (client?.id != null) petzClientId = String(client.id);
+    } catch { /* enrichment é best-effort; cart resolve via fallback */ }
+    return { status: vr.status, data: vdata, deviceId, petzClientId };
+  }, { cpf, code });
+
+  if (out.status !== 200 || !out.data?.access_token) {
+    return { success: false, status: out.status, data: out.data };
   }
-  return { success: res.status === 200, status: res.status, cookies, data: res.data };
+  return {
+    success: true,
+    status: out.status,
+    accessToken: out.data.access_token,
+    refreshToken: out.data.refresh_token,
+    expiresIn: out.data.expires_in ?? 3600,
+    petzClientId: out.petzClientId ?? null,
+    deviceId: out.deviceId || null,
+    data: out.data,
+  };
 }
 
 export async function closePetzOtp(stagehand) {

--- a/src/api/workers/petz-otp-runner.js
+++ b/src/api/workers/petz-otp-runner.js
@@ -27,7 +27,14 @@ let active = null; // { stagehand, page }
         try {
           const res = await verifyPetzOtp({ page: active.page, cpf: data.cpf, code: msg.code });
           process.send(res.success
-            ? { status: 'success', cookies: res.cookies }
+            ? {
+                status: 'success',
+                accessToken: res.accessToken,
+                refreshToken: res.refreshToken,
+                expiresIn: res.expiresIn,
+                petzClientId: res.petzClientId,
+                deviceId: res.deviceId,
+              }
             : { status: 'invalid_code', httpStatus: res.status });
         } catch (err) {
           process.send({ status: 'error', message: err.message });

--- a/src/api/workers/petz-otp-runner.js
+++ b/src/api/workers/petz-otp-runner.js
@@ -1,0 +1,50 @@
+// Worker do fluxo Petz OTP quick-access (caminho B). Espelha login-petz-runner.js:
+// start (access + send) -> awaiting_code -> submit_code (verify) -> success/erro.
+// A sessão Browserbase fica viva entre o send e o verify (tutor manda o código no chat).
+
+import { startPetzOtp, verifyPetzOtp, closePetzOtp } from '../services/petz-otp.service.js';
+
+const data = JSON.parse(process.argv[2] || '{}');
+
+let active = null; // { stagehand, page }
+
+(async () => {
+  try {
+    const result = await startPetzOtp({ cpf: data.cpf, channel: data.channel });
+    active = { stagehand: result.stagehand, page: result.page };
+
+    process.send({
+      status: 'awaiting_code',
+      sessionId: data.sessionId,
+      exists: result.exists,
+      maskedPhone: result.maskedPhone,
+      hasWppRetry: result.hasWppRetry,
+      sendStatus: result.sendStatus,
+    });
+
+    process.on('message', async (msg) => {
+      if (msg?.action === 'submit_code') {
+        try {
+          const res = await verifyPetzOtp({ page: active.page, cpf: data.cpf, code: msg.code });
+          process.send(res.success
+            ? { status: 'success', cookies: res.cookies }
+            : { status: 'invalid_code', httpStatus: res.status });
+        } catch (err) {
+          process.send({ status: 'error', message: err.message });
+        } finally {
+          await closePetzOtp(active.stagehand);
+          process.exit(0);
+        }
+      }
+    });
+
+    // segurança: encerra a sessão se o código não vier (igual ao login runner)
+    setTimeout(async () => {
+      await closePetzOtp(active?.stagehand);
+      process.exit(1);
+    }, 5 * 60 * 1000);
+  } catch (err) {
+    process.send({ status: 'error', message: err.message });
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
Caminho B do connect-or-create Petz (issue `petz-connect-mandatory-onboarding` no repo Latta, PR #541). Como o external proxy do Browserbase está indisponível na conta (caminho A bloqueado, §11), o OTP roda **dentro do Browserbase** (IP do Browserbase passa o Akamai — provado pelo login Petz de prod).

- `petz-otp.service.js`: `startPetzOtp` (abre sessão Browserbase, `/access` masked + envia código SMS/WPP, mantém sessão viva) + `verifyPetzOtp` (valida o código na MESMA sessão) + `closePetzOtp`.
- `petz-otp-runner.js`: worker fork `start → awaiting_code → submit_code → verify` (espelha `login-petz-runner`, keepAlive entre send e verify).
- `petz-otp.controller.js` + rotas `POST /web-scrapping/petz/otp/{start,verify}`: sessão viva por sessionId (md5 cpf).

**Validação E2E pendente:** precisa de 1 sessão Browserbase + um código real (rodar `otp/start` com um CPF de teste, receber o código, `otp/verify`). Próximo: EF chamar esses endpoints no gate do e-commerce (fatia #03/#04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)