### PR TITLE
feat(backend): endpoint /petz/access (lookup do número mascarado)

### DIFF
--- a/src/api/controllers/petz-access.controller.js
+++ b/src/api/controllers/petz-access.controller.js
@@ -1,0 +1,29 @@
+// Controller do lookup do número mascarado Petz (diligência "final XXXX").
+// Chamada única e stateless (não mantém sessão viva como o antigo OTP worker).
+// Latência ~15-17s (Browserbase + /access in-browser) — por isso é chamado em
+// BACKGROUND pela onboarding-service EF, nunca no caminho síncrono do Flow.
+
+import { lookupMaskedPhone } from '../services/petz-access.service.js';
+
+// POST /web-scrapping/petz/access  { cpf }
+// -> { success, exists, maskedPhone, hasWppRetry }
+const petzAccessLookup = async (req, res) => {
+  const { cpf } = req.body || {};
+  if (!cpf) return res.status(400).json({ code: 'INVALID_DATA', message: 'cpf é obrigatório' });
+
+  const cleanCpf = String(cpf).replace(/\D/g, '');
+  if (cleanCpf.length !== 11) return res.status(400).json({ code: 'INVALID_DATA', message: 'cpf inválido' });
+
+  try {
+    const result = await Promise.race([
+      lookupMaskedPhone({ cpf: cleanCpf }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('TIMEOUT')), 60 * 1000)),
+    ]);
+    return res.status(200).json({ success: true, ...result });
+  } catch (err) {
+    const code = err.message === 'TIMEOUT' ? 504 : 500;
+    return res.status(code).json({ success: false, code: 'ACCESS_LOOKUP_ERROR', message: err.message });
+  }
+};
+
+export default { petzAccessLookup };

--- a/src/api/routes/private/web-scrapping.route.js
+++ b/src/api/routes/private/web-scrapping.route.js
@@ -1,10 +1,14 @@
 import { Router } from 'express';
 import WebScrappingController from '../../controllers/web-scarpping.controller.js';
+import PetzAccessController from '../../controllers/petz-access.controller.js';
 
 const router = Router();
 
 router.post('/login-petz', WebScrappingController.loginPetz);
 router.post('/petz/sms', WebScrappingController.submitSmsCode);
 router.post('/login-cobasi', WebScrappingController.loginCobasi);
+
+// Lookup do número mascarado da conta Petz (diligência "final XXXX" no onboarding)
+router.post('/petz/access', PetzAccessController.petzAccessLookup);
 
 export default router;

--- a/src/api/services/petz-access.service.js
+++ b/src/api/services/petz-access.service.js
@@ -1,0 +1,66 @@
+// Lookup do número mascarado da conta Petz via /access (diligência "final XXXX").
+//
+// O /access (`/api/v3/public/client/access`) é Akamai-protegido — 403 em chamada
+// crua, mesmo via IProyal. A única forma de passar é DENTRO de um browser stealth
+// (Browserbase), que o Akamai aceita. Esta é uma chamada única e curta (~15-17s):
+// abre a página de login, dispara o /access in-browser, devolve o mascarado.
+// NÃO mantém sessão viva (diferente do antigo worker B de OTP). Latência medida
+// 2026-06-10: ~17s (init ~5s + page load ~10s + fetch ~1s).
+
+import 'dotenv/config';
+import { Stagehand } from '@browserbasehq/stagehand';
+
+const PETZ_BASE = 'https://www.petz.com.br';
+const LOGIN_URL = `${PETZ_BASE}/checkout/login/indexLogado_Loja`;
+
+function newStagehand() {
+  const useCloud = process.env.USE_BROWSERBASE === 'true';
+  return new Stagehand({
+    env: useCloud ? 'BROWSERBASE' : 'LOCAL',
+    apiKey: process.env.BROWSERBASE_API_KEY,
+    projectId: process.env.BROWSERBASE_PROJECT_ID,
+    enableCaching: false,
+    ...(useCloud
+      ? { browserbaseSessionCreateParams: { keepAlive: false, timeout: 120 } }
+      : {
+          localBrowserLaunchOptions: {
+            headless: true,
+            ...(process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : {}),
+            args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--lang=pt-BR'],
+          },
+        }),
+  });
+}
+
+/**
+ * Identifica a conta Petz pelo CPF e devolve o número mascarado cadastrado.
+ * @param {{cpf: string}} params
+ * @returns {Promise<{exists: boolean, maskedPhone: string|null, hasWppRetry: boolean}>}
+ */
+export async function lookupMaskedPhone({ cpf }) {
+  const stagehand = newStagehand();
+  await stagehand.init();
+  const page = stagehand.page;
+  try {
+    await page.goto(LOGIN_URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    const out = await page.evaluate(async (cpf) => {
+      const r = await fetch('/api/v3/public/client/access', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json; charset=UTF-8', versionapi: '3' },
+        body: JSON.stringify({ cpf, tipoToken: 'access_token' }),
+      });
+      let d = null;
+      try { d = await r.json(); } catch { /* ok */ }
+      return { status: r.status, data: d };
+    }, cpf);
+
+    const ca = out?.data?.result?.clientAccess;
+    return {
+      exists: !!ca,
+      maskedPhone: ca?.cellphone ?? null,
+      hasWppRetry: !!ca?.hasWppRetry,
+    };
+  } finally {
+    await stagehand.close().catch(() => {});
+  }
+}


### PR DESCRIPTION
Endpoint pro lookup do número mascarado da conta Petz, pra diligência "código foi pro final XXXX" no onboarding.

`POST /web-scrapping/petz/access {cpf}` → `{success, exists, maskedPhone, hasWppRetry}`

- Faz o `/access` da Petz **dentro do Browserbase** (Akamai bloqueia crú — 403 mesmo via IProyal, confirmado).
- Chamada **única e stateless** (~16s), sem sessão viva (diferente do antigo OTP worker).
- Chamado em **background** pela onboarding-service EF → mostra "final XXXX" no reenviar do código.
- Validado: CPF de teste → `*******7909`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)