### PR TITLE
fix(backend): painel da clínica — segurança das rotas de scheduling + timezone (grupo H: H1/H4/H6)

### DIFF
--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -144,7 +144,10 @@ const getSchedulingsByPetOwner = async (req, res) => {
     const { petOwnerId } = req.params;
     const { date, status } = req.query;
 
-    if (req.user.role === 'petOwner' && req.user.id !== petOwnerId) {
+    // getRoleString: o role no JWT é objeto ({ role: 'petOwner' }), não string —
+    // `req.user.role === 'petOwner'` era sempre false e o guard não disparava
+    // (IDOR: tutor lia agendamentos + email de outro tutor).
+    if (getRoleString(req) === 'petOwner' && req.user.id !== petOwnerId) {
       return res.status(403).json({
         code: 'FORBIDDEN',
         message: 'Você não tem permissão para acessar agendamentos de outros donos de pets',
@@ -179,7 +182,7 @@ const getSchedulingsByPet = async (req, res) => {
     });
 
     if (
-      req.user.role === 'petOwner' &&
+      getRoleString(req) === 'petOwner' &&
       schedulings.length > 0 &&
       schedulings[0].pet_owner_id !== req.user.id
     ) {

--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -45,11 +45,34 @@ const handleError = (res, error, fallback) => {
 
 const createScheduling = async (req, res) => {
   try {
-    const body = Array.isArray(req.body) ? req.body : [req.body];
+    let body = Array.isArray(req.body) ? req.body : [req.body];
+
+    // Anti-bypass: role clinic só cria agendamento na própria clínica
+    // (clinic_id vem do JWT) e só pra clientes próprios (external_*) —
+    // pet_id/pet_owner_id do body são descartados pra impedir agendamento
+    // falso pendurado num tutor Latta (e o JOIN devolveria PII dele).
+    if (isClinicRole(req)) {
+      const jwtClinicId = getClinicId(req);
+      if (!jwtClinicId) {
+        return res.status(403).json({
+          code: 'CLINIC_FORBIDDEN',
+          message: 'JWT sem clinic_id',
+        });
+      }
+      body = body.map((item) => ({
+        ...item,
+        clinic_id: jwtClinicId,
+        pet_id: null,
+        pet_ids: null,
+        pet_owner_id: null,
+        user_phone: null,
+      }));
+    }
+
     const created = await SchedulingService.createScheduling({ schedulingData: body });
     return res.status(201).json({
       code: 'SCHEDULING_CREATED',
-      data: created,
+      data: isClinicRole(req) ? redactAppointmentsForClinic(created) : created,
     });
   } catch (error) {
     return handleError(res, error, {
@@ -349,10 +372,13 @@ const rescheduleScheduling = async (req, res) => {
         reason: reason || 'remarcado pela clinica via painel',
       });
     } else {
+      // External: o repo só grava a data via resolveScheduledDate(appointment_date,
+      // start_time) — `scheduled_date` direto é ignorado (UPDATABLE_COLUMNS pula a
+      // key). Passar como start_time (ISO 8601) pra data nova ser persistida.
       await SchedulingService.updateScheduling({
         id,
         schedulingData: {
-          scheduled_date: new_scheduled_date,
+          start_time: new_scheduled_date,
           ...(new_scheduled_service ? { scheduled_service: new_scheduled_service } : {}),
         },
       });

--- a/src/api/routes/private/scheduling.routes.js
+++ b/src/api/routes/private/scheduling.routes.js
@@ -1,102 +1,115 @@
 import { Router } from 'express';
 import SchedulingController from '../../controllers/scheduling.controller.js';
 import { verifyToken, checkRole } from '../../middlewares/auth.middleware.js';
+import { requireClinicPortalFlag } from '../../middlewares/clinic-portal-flag.middleware.js';
 
 const router = Router();
 
-// Criar um novo agendamento
+// Role 'clinic' só entra em rotas cujo controller tem guard de clinic_id +
+// redaction. Rotas sem scoping por clínica (lista geral, por-pet, por-tutor,
+// update/confirm/delete genéricos) vazariam phone/email de tutores de outras
+// clínicas — ficam admin-only. requireClinicPortalFlag: gate server-side do
+// beta clinic_portal_v0 (no-op pra admin/superAdmin/petOwner).
+
+// Criar um novo agendamento (role clinic: controller força clinic_id do JWT)
 router.post(
   '/',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'petOwner', 'clinic']),
+  requireClinicPortalFlag,
   SchedulingController.createScheduling,
 );
 
-// Obter todos os agendamentos
+// Obter todos os agendamentos (lista geral, sem scoping — admin-only)
 router.get(
   '/',
   verifyToken,
-  checkRole(['admin', 'superAdmin', 'clinic']),
+  checkRole(['admin', 'superAdmin']),
   SchedulingController.getAllSchedulings,
 );
 
-// Obter agendamentos por clínica
+// Obter agendamentos por clínica (controller tem anti-bypass + redaction)
 router.get(
   '/clinic/:clinicId',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'clinic']),
+  requireClinicPortalFlag,
   SchedulingController.getSchedulingsByClinic,
 );
 
-// Obter agendamentos por dono de pet
+// Obter agendamentos por dono de pet (sem scoping por clínica — clinic fora)
 router.get(
   '/pet-owner/:petOwnerId',
   verifyToken,
-  checkRole(['admin', 'superAdmin', 'petOwner', 'clinic']),
+  checkRole(['admin', 'superAdmin', 'petOwner']),
   SchedulingController.getSchedulingsByPetOwner,
 );
 
-// Obter agendamentos por pet
+// Obter agendamentos por pet (sem scoping por clínica — clinic fora)
 router.get(
   '/pet/:petId',
   verifyToken,
-  checkRole(['admin', 'superAdmin', 'petOwner', 'clinic']),
+  checkRole(['admin', 'superAdmin', 'petOwner']),
   SchedulingController.getSchedulingsByPet,
 );
 
-// Obter um agendamento específico pelo ID
+// Obter um agendamento específico pelo ID (controller tem guard + redaction)
 router.get(
   '/:id',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'petOwner', 'clinic']),
+  requireClinicPortalFlag,
   SchedulingController.getSchedulingById,
 );
 
-// Atualizar um agendamento
+// Atualizar um agendamento (edição genérica sem guard de ownership — admin-only)
 router.put(
   '/:id',
   verifyToken,
-  checkRole(['admin', 'superAdmin', 'clinic']),
+  checkRole(['admin', 'superAdmin']),
   SchedulingController.updateScheduling,
 );
 
-// Cancelar um agendamento
+// Cancelar um agendamento (controller tem guard de ownership pra clinic)
 router.patch(
   '/:id/cancel',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'petOwner', 'clinic']),
+  requireClinicPortalFlag,
   SchedulingController.cancelScheduling,
 );
 
-// Marcar no-show (tutor nao compareceu)
+// Marcar no-show (controller tem guard de ownership pra clinic)
 router.patch(
   '/:id/no-show',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'clinic']),
+  requireClinicPortalFlag,
   SchedulingController.noShowScheduling,
 );
 
-// Remarcar agendamento
+// Remarcar agendamento (controller tem guard de ownership pra clinic)
 router.patch(
   '/:id/reschedule',
   verifyToken,
   checkRole(['admin', 'superAdmin', 'clinic']),
+  requireClinicPortalFlag,
   SchedulingController.rescheduleScheduling,
 );
 
-// Confirmar um agendamento
+// Confirmar um agendamento (sem guard de ownership — admin-only)
 router.patch(
   '/:id/confirm',
   verifyToken,
-  checkRole(['admin', 'superAdmin', 'clinic']),
+  checkRole(['admin', 'superAdmin']),
   SchedulingController.confirmScheduling,
 );
 
-// Remover um agendamento
+// Remover um agendamento (hard delete — admin-only)
 router.delete(
   '/:id',
   verifyToken,
-  checkRole(['admin', 'superAdmin', 'clinic']),
+  checkRole(['admin', 'superAdmin']),
   SchedulingController.deleteScheduling,
 );
 

--- a/src/api/utils/scheduling.mapper.js
+++ b/src/api/utils/scheduling.mapper.js
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon';
+
 export const STATE_LABELS = {
   INITIATED: 'Iniciado',
   CONTACTING: 'Contatando clínica',
@@ -13,11 +15,16 @@ export const STATE_LABELS = {
   ESCALATED: 'Escalado',
 };
 
+// appointment_date é o "dia do serviço" na agenda — precisa ser o dia em
+// horário de Brasília, não UTC. Com toISOString (UTC), serviço 21h+ BRT
+// caía no dia seguinte no grid.
+const SCHEDULE_TZ = 'America/Sao_Paulo';
+
 const toISODate = (value) => {
   if (!value) return null;
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) return null;
-  return date.toISOString().slice(0, 10);
+  return DateTime.fromJSDate(date).setZone(SCHEDULE_TZ).toISODate();
 };
 
 export function mapSessionToScheduling(row) {


### PR DESCRIPTION
## Contexto

Grupo H do plano `docs/issues/scheduling-manutencao-pos-30-06/PLANO-EXECUCAO.md` (repo principal). Par deste PR no frontend: Latta-app/frontend (H2+H3).

## H1 — Segurança P0: role clinic sem guard nem redaction

`GET /api/scheduling` permitia role `clinic` listar agendamentos de **todas** as clínicas com telefone/email dos tutores. Na implementação, encontrei mais 5 rotas da mesma classe no mesmo arquivo — todas sem guard de `clinic_id` e sem redaction:

| Rota | Antes | Agora |
|---|---|---|
| `GET /` (lista geral) | clinic lia tudo, sem redaction | admin-only |
| `GET /pet-owner/:id` | clinic lia qualquer tutor | admin/petOwner |
| `GET /pet/:id` | clinic lia qualquer pet | admin/petOwner |
| `PUT /:id` | clinic editava qualquer agendamento | admin-only |
| `PATCH /:id/confirm` | clinic confirmava qualquer um | admin-only |
| `DELETE /:id` | clinic apagava qualquer um (hard delete) | admin-only |
| `POST /` | clinic criava com `clinic_id`/`pet_owner_id` arbitrários do body | `clinic_id` forçado do JWT; `pet_id`/`pet_owner_id`/`user_phone` descartados; resposta redigida |

O portal da clínica não usa nenhuma das rotas removidas (só `GET /clinic/:id`, `POST /`, cancel/no-show/reschedule — todas com guard anti-bypass + redaction no controller).

## H6 — Flag beta server-side

`requireClinicPortalFlag` (gate da `clinic_portal_v0`, no-op pra outras roles) aplicado em todas as rotas de scheduling que aceitam role clinic. Antes o gate era só client-side (ClinicPortalGate).

## H4 — Timezone

`scheduling.mapper.js` bucketizava `appointment_date` em UTC (`toISOString`): serviço 21h+ BRT caía no dia seguinte no grid. Agora converte pra `America/Sao_Paulo` via luxon.

## Fix extra (achado no review): remarcar external era no-op

O branch external de `PATCH /:id/reschedule` passava `scheduled_date`, que o repo ignora (`UPDATABLE_COLUMNS` pula a key e `resolveScheduledDate` só olha `appointment_date`/`start_time`) → 200 de sucesso sem gravar nada. Agora passa `start_time` (ISO), que o repo resolve corretamente.

## Validação

- `node --check` nos 3 arquivos.
- Mapper testado com a row real da Íris (`df7a1464`, `2026-07-01T19:30Z` → `2026-07-01` ✓) e caso 21h30 BRT (antes `2026-07-02`, agora `2026-07-01` ✓); inputs string e null OK.
- H5 (read-only, sem código): `CLINIC_AUTH_JWT_SECRET` **não está setada** no EC2 → `clinic-auth.service` usa o fallback `JWT_SECRET` → assina e verifica com o mesmo secret, sem risco de 401.
- Review adversarial multi-agente (4 dimensões × 3 verificadores por finding): 2 findings P1 confirmados e corrigidos neste PR (POST sem redaction/scoping de pet_owner; reschedule no-op).

## Follow-up sugerido (fora do escopo)

- Guard de transição de estado no backend pra external (hoje cancel/no-show sobrescrevem estado terminal incondicionalmente — o frontend novo já bloqueia na UI).
- Filtro SQL `?date=` usa dia UTC (`::date`) enquanto `appointment_date` agora é dia BRT — o painel não passa `date`, mas vale alinhar.

⚠️ **Não deployar no EC2 sem aprovação explícita do operador.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)