### PR TITLE
fix(backend): hardening de authz do portal da clínica (H-2 — 5 findings)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "start": "node src/app.js",
     "dev": "nodemon --inspect -r sucrase/register src/app.js --ignore tmp/",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "eslint:fix": "eslint --fix src",
     "eslint:check": "eslint src",
     "prettier:format": "prettier --config .prettierrc 'src/**/*.js*' --loglevel=silent --write",

--- a/src/api/__tests__/auth-middleware.test.js
+++ b/src/api/__tests__/auth-middleware.test.js
@@ -1,0 +1,37 @@
+// H-2 #5 — routeGuard era dead code quebrado (req.user.role?.toLowerCase() num
+// role objeto → TypeError → 500 fail-closed). Foi removido. Este teste garante
+// que o landmine sumiu e que checkRole (o guard de fato usado) lida com o role
+// no formato objeto ({ role: 'x' }).
+import { describe, it, expect, vi } from 'vitest';
+import * as authMw from '../middlewares/auth.middleware.js';
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+describe('#5 — routeGuard removido + checkRole com role objeto', () => {
+  it('routeGuard não é mais exportado (landmine removido)', () => {
+    expect(authMw.routeGuard).toBeUndefined();
+  });
+
+  it('checkRole bloqueia role {role:"clinic"} fora da lista → 403 (não 500)', () => {
+    const req = { user: { role: { role: 'clinic' } } };
+    const res = mockRes();
+    const next = vi.fn();
+    authMw.checkRole(['admin', 'superAdmin'])(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('checkRole libera role {role:"admin"} na lista → next, sem 500', () => {
+    const req = { user: { role: { role: 'admin' } } };
+    const res = mockRes();
+    const next = vi.fn();
+    authMw.checkRole(['admin', 'superAdmin'])(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/__tests__/helpers.js
+++ b/src/api/__tests__/helpers.js
@@ -1,0 +1,63 @@
+// Helpers compartilhados da suite de authz (H-2).
+// verifyToken lê process.env.JWT_SECRET em request-time, então fixamos o segredo
+// aqui (import mais cedo) e assinamos os tokens de teste com o mesmo valor.
+import http from 'node:http';
+import jwt from 'jsonwebtoken';
+
+export const TEST_SECRET = 'h2-authz-test-secret';
+process.env.JWT_SECRET = TEST_SECRET;
+
+export const signToken = (payload) => jwt.sign(payload, TEST_SECRET, { expiresIn: '1h' });
+
+// role no JWT é objeto ({ role: 'x' }) — igual ao token real emitido por
+// auth.service.generateToken (user.role é objeto no banco).
+export const clinicToken = (over = {}) =>
+  signToken({
+    id: 'clinic-user-1',
+    email: 'clinica@example.com',
+    role: { role: 'clinic' },
+    clinic_id: 'clinic-aaaa-1111',
+    ...over,
+  });
+
+export const adminToken = (over = {}) =>
+  signToken({ id: 'admin-1', email: 'admin@latta.com', role: { role: 'admin' }, ...over });
+
+export const superAdminToken = (over = {}) =>
+  signToken({ id: 'sa-1', email: 'sa@latta.com', role: { role: 'superAdmin' }, ...over });
+
+export const petOwnerToken = (over = {}) =>
+  signToken({
+    id: 'owner-self-1',
+    email: 'tutor@example.com',
+    role: { role: 'petOwner' },
+    ...over,
+  });
+
+// Dispara um request HTTP real contra o app Express (sem supertest): sobe um
+// servidor efêmero, usa o fetch nativo do Node e fecha o servidor no fim.
+export async function httpRequest(app, { method = 'GET', path = '/', token, body } = {}) {
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address();
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    let parsed;
+    try {
+      parsed = text ? JSON.parse(text) : null;
+    } catch {
+      parsed = text;
+    }
+    return { status: res.status, body: parsed };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}

--- a/src/api/__tests__/pet-owner-authz.test.js
+++ b/src/api/__tests__/pet-owner-authz.test.js
@@ -1,0 +1,67 @@
+// H-2 #1/#2 — /pet-owner/* precisa de checkRole excluindo 'clinic'.
+// O controller/service/repo são mockados: só testamos os guards de role do
+// arquivo de rotas (verifyToken + checkRole), não o acesso a dados.
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import express from 'express';
+import { httpRequest, clinicToken, adminToken, superAdminToken, petOwnerToken } from './helpers.js';
+
+// Substitui o controller inteiro — evita carregar service→repo→models→Sequelize.
+// Cada handler devolve 200 pra distinguir "guard passou" de "guard bloqueou".
+vi.mock('../controllers/pet-owner.controller.js', () => ({
+  default: {
+    createPetOwner: (req, res) => res.status(200).json({ reached: 'create' }),
+    getAllPetOwners: (req, res) => res.status(200).json({ reached: 'getAll' }),
+    getPetOwnerById: (req, res) => res.status(200).json({ reached: 'getById' }),
+    updatePetOwner: (req, res) => res.status(200).json({ reached: 'update' }),
+    deletePetOwner: (req, res) => res.status(200).json({ reached: 'delete' }),
+    searchPetOwners: (req, res) => res.status(200).json({ reached: 'search' }),
+  },
+}));
+
+let app;
+beforeAll(async () => {
+  const { default: petOwnerRoutes } = await import('../routes/private/pet-owners.routes.js');
+  app = express();
+  app.use(express.json());
+  app.use('/api/pet-owner', petOwnerRoutes);
+});
+
+const ROUTES = [
+  { method: 'POST', path: '/api/pet-owner', body: {} },
+  { method: 'GET', path: '/api/pet-owner' },
+  { method: 'GET', path: '/api/pet-owner/some-id' },
+  { method: 'PUT', path: '/api/pet-owner/some-id', body: {} },
+  { method: 'DELETE', path: '/api/pet-owner/some-id' },
+  { method: 'GET', path: '/api/pet-owner/search/joao' },
+];
+
+describe('#1/#2 — /pet-owner authz', () => {
+  it('bloqueia token de CLÍNICA com 403 em todas as 6 rotas', async () => {
+    for (const r of ROUTES) {
+      const res = await httpRequest(app, { ...r, token: clinicToken() });
+      expect(res.status, `${r.method} ${r.path}`).toBe(403);
+      expect(res.body.code, `${r.method} ${r.path}`).toBe('AUTH_FORBIDDEN');
+    }
+  });
+
+  it('bloqueia token de petOwner com 403 (superfície é admin-only)', async () => {
+    for (const r of ROUTES) {
+      const res = await httpRequest(app, { ...r, token: petOwnerToken() });
+      expect(res.status, `${r.method} ${r.path}`).toBe(403);
+    }
+  });
+
+  it('retorna 401 sem token', async () => {
+    const res = await httpRequest(app, { method: 'GET', path: '/api/pet-owner' });
+    expect(res.status).toBe(401);
+  });
+
+  it('PERMITE admin e superAdmin (consumidores legítimos do painel)', async () => {
+    for (const token of [adminToken(), superAdminToken()]) {
+      for (const r of ROUTES) {
+        const res = await httpRequest(app, { ...r, token });
+        expect(res.status, `${r.method} ${r.path}`).toBe(200);
+      }
+    }
+  });
+});

--- a/src/api/__tests__/scheduling-by-pet-authz.test.js
+++ b/src/api/__tests__/scheduling-by-pet-authz.test.js
@@ -1,0 +1,68 @@
+// H-2 #4 (camada controller) — getSchedulingsByPet escopa por dono no repo.
+// Verifica que o controller passa petOwnerId = req.user.id pra role petOwner e
+// undefined pra admin (que vê tudo), e que clinic nem alcança a rota.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import { httpRequest, petOwnerToken, adminToken, clinicToken } from './helpers.js';
+
+vi.mock('../services/scheduling.service.js', () => ({
+  default: {
+    getSchedulingsByPet: vi.fn(async () => [
+      { id: 'a', pet_owner_id: 'someone-else', user_phone: '5511999999999' },
+    ]),
+  },
+}));
+vi.mock('../services/merchant-scheduling-agent.service.js', () => ({ default: {} }));
+vi.mock('../services/clinic-activity-log.service.js', () => ({ logFromReq: vi.fn(), default: {} }));
+vi.mock('../middlewares/clinic-portal-flag.middleware.js', () => ({
+  requireClinicPortalFlag: (req, res, next) => next(),
+  default: (req, res, next) => next(),
+}));
+
+const OWNER_ID = '33333333-3333-3333-3333-333333333333';
+
+let app;
+let SchedulingService;
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ default: SchedulingService } = await import('../services/scheduling.service.js'));
+  const { default: schedulingRoutes } = await import('../routes/private/scheduling.routes.js');
+  app = express();
+  app.use(express.json());
+  app.use('/api/scheduling', schedulingRoutes);
+});
+
+describe('#4 — getSchedulingsByPet scoping', () => {
+  it('petOwner: repo é chamado com petOwnerId = req.user.id', async () => {
+    const res = await httpRequest(app, {
+      method: 'GET',
+      path: '/api/scheduling/pet/PET1',
+      token: petOwnerToken({ id: OWNER_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(SchedulingService.getSchedulingsByPet).toHaveBeenCalledWith(
+      expect.objectContaining({ petId: 'PET1', petOwnerId: OWNER_ID }),
+    );
+  });
+
+  it('admin: repo é chamado sem escopo de dono (vê tudo)', async () => {
+    const res = await httpRequest(app, {
+      method: 'GET',
+      path: '/api/scheduling/pet/PET1',
+      token: adminToken(),
+    });
+    expect(res.status).toBe(200);
+    const arg = SchedulingService.getSchedulingsByPet.mock.calls[0][0];
+    expect(arg.petOwnerId).toBeUndefined();
+  });
+
+  it('clinic nem alcança a rota (403 no checkRole)', async () => {
+    const res = await httpRequest(app, {
+      method: 'GET',
+      path: '/api/scheduling/pet/PET1',
+      token: clinicToken(),
+    });
+    expect(res.status).toBe(403);
+    expect(SchedulingService.getSchedulingsByPet).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/__tests__/scheduling-by-pet-authz.test.js
+++ b/src/api/__tests__/scheduling-by-pet-authz.test.js
@@ -56,6 +56,17 @@ describe('#4 — getSchedulingsByPet scoping', () => {
     expect(arg.petOwnerId).toBeUndefined();
   });
 
+  it('petOwner sem id no token → 403 (não cai no unscoped)', async () => {
+    // token de tutor forjado sem id: role petOwner mas id ausente
+    const res = await httpRequest(app, {
+      method: 'GET',
+      path: '/api/scheduling/pet/PET1',
+      token: petOwnerToken({ id: undefined }),
+    });
+    expect(res.status).toBe(403);
+    expect(SchedulingService.getSchedulingsByPet).not.toHaveBeenCalled();
+  });
+
   it('clinic nem alcança a rota (403 no checkRole)', async () => {
     const res = await httpRequest(app, {
       method: 'GET',

--- a/src/api/__tests__/scheduling-create-authz.test.js
+++ b/src/api/__tests__/scheduling-create-authz.test.js
@@ -1,0 +1,129 @@
+// H-2 #3 — createScheduling não pode deixar petOwner forjar/vazar.
+// Monta a rota real + controller real + validators/redactor reais; só a camada
+// de serviço/DB é mockada. Verifica bind de pet_owner_id, ownership do pet e
+// redação da resposta.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import { httpRequest, petOwnerToken, adminToken } from './helpers.js';
+
+vi.mock('../services/scheduling.service.js', () => ({
+  default: {
+    createScheduling: vi.fn(async ({ schedulingData }) =>
+      schedulingData.map((s, i) => ({
+        id: `sess-${i}`,
+        clinic_id: s.clinic_id,
+        pet_id: s.pet_id,
+        pet_owner_id: s.pet_owner_id,
+        user_phone: s.user_phone ?? '5511999999999',
+        petOwner: { id: s.pet_owner_id, email: 'leak-victim@example.com', name: 'Fulano' },
+      })),
+    ),
+    petBelongsToOwner: vi.fn(async () => true),
+  },
+}));
+vi.mock('../services/merchant-scheduling-agent.service.js', () => ({ default: {} }));
+vi.mock('../services/clinic-activity-log.service.js', () => ({
+  logFromReq: vi.fn(),
+  default: {},
+}));
+vi.mock('../middlewares/clinic-portal-flag.middleware.js', () => ({
+  requireClinicPortalFlag: (req, res, next) => next(),
+  default: (req, res, next) => next(),
+}));
+
+const OWNER_ID = '33333333-3333-3333-3333-333333333333';
+const VICTIM_OWNER_ID = '99999999-9999-9999-9999-999999999999';
+const PET_ID = '22222222-2222-2222-2222-222222222222';
+const CLINIC_ID = '11111111-1111-1111-1111-111111111111';
+const VALID = {
+  clinic_id: CLINIC_ID,
+  appointment_date: '2026-08-01',
+  start_time: '10:00',
+  pet_id: PET_ID,
+};
+
+let app;
+let SchedulingService;
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ default: SchedulingService } = await import('../services/scheduling.service.js'));
+  SchedulingService.petBelongsToOwner.mockResolvedValue(true);
+  const { default: schedulingRoutes } = await import('../routes/private/scheduling.routes.js');
+  app = express();
+  app.use(express.json());
+  app.use('/api/scheduling', schedulingRoutes);
+});
+
+describe('#3 — createScheduling bind do petOwner', () => {
+  it('403 quando o pet_id não pertence ao tutor', async () => {
+    SchedulingService.petBelongsToOwner.mockResolvedValueOnce(false);
+    const res = await httpRequest(app, {
+      method: 'POST',
+      path: '/api/scheduling',
+      token: petOwnerToken({ id: OWNER_ID }),
+      body: { ...VALID, pet_owner_id: VICTIM_OWNER_ID },
+    });
+    expect(res.status).toBe(403);
+    expect(SchedulingService.createScheduling).not.toHaveBeenCalled();
+  });
+
+  it('força pet_owner_id = req.user.id, ignora o do body e zera user_phone', async () => {
+    const res = await httpRequest(app, {
+      method: 'POST',
+      path: '/api/scheduling',
+      token: petOwnerToken({ id: OWNER_ID }),
+      body: { ...VALID, pet_owner_id: VICTIM_OWNER_ID, user_phone: '5511888888888' },
+    });
+    expect(res.status).toBe(201);
+    const arg = SchedulingService.createScheduling.mock.calls[0][0].schedulingData;
+    expect(arg[0].pet_owner_id).toBe(OWNER_ID);
+    expect(arg[0].pet_owner_id).not.toBe(VICTIM_OWNER_ID);
+    expect(arg[0].user_phone).toBeNull();
+    expect(SchedulingService.petBelongsToOwner).toHaveBeenCalledWith({
+      petId: PET_ID,
+      petOwnerId: OWNER_ID,
+    });
+  });
+
+  it('redige a resposta do petOwner (sem email/phone)', async () => {
+    const res = await httpRequest(app, {
+      method: 'POST',
+      path: '/api/scheduling',
+      token: petOwnerToken({ id: OWNER_ID }),
+      body: { ...VALID, pet_owner_id: VICTIM_OWNER_ID },
+    });
+    expect(res.status).toBe(201);
+    const row = res.body.data[0];
+    expect(row.user_phone).toBeNull();
+    expect(row.petOwner.email).toBeNull();
+    expect(row.petOwner.name).toBe('Fulano'); // nome é permitido
+  });
+
+  it('400 quando petOwner não manda pet_id', async () => {
+    const { pet_id, ...noPet } = VALID;
+    void pet_id;
+    const res = await httpRequest(app, {
+      method: 'POST',
+      path: '/api/scheduling',
+      token: petOwnerToken({ id: OWNER_ID }),
+      body: noPet,
+    });
+    expect(res.status).toBe(400);
+    expect(SchedulingService.createScheduling).not.toHaveBeenCalled();
+  });
+
+  it('admin passa direto: body preservado, resposta NÃO redigida', async () => {
+    const res = await httpRequest(app, {
+      method: 'POST',
+      path: '/api/scheduling',
+      token: adminToken(),
+      body: { ...VALID, pet_owner_id: VICTIM_OWNER_ID, user_phone: '5511777777777' },
+    });
+    expect(res.status).toBe(201);
+    const arg = SchedulingService.createScheduling.mock.calls[0][0].schedulingData;
+    expect(arg[0].pet_owner_id).toBe(VICTIM_OWNER_ID); // admin não é sanitizado
+    expect(arg[0].user_phone).toBe('5511777777777');
+    expect(SchedulingService.petBelongsToOwner).not.toHaveBeenCalled();
+    expect(res.body.data[0].petOwner.email).toBe('leak-victim@example.com'); // sem redação
+  });
+});

--- a/src/api/__tests__/scheduling-create-authz.test.js
+++ b/src/api/__tests__/scheduling-create-authz.test.js
@@ -19,6 +19,7 @@ vi.mock('../services/scheduling.service.js', () => ({
       })),
     ),
     petBelongsToOwner: vi.fn(async () => true),
+    getPetOwnerClinicId: vi.fn(async () => null),
   },
 }));
 vi.mock('../services/merchant-scheduling-agent.service.js', () => ({ default: {} }));
@@ -35,6 +36,7 @@ const OWNER_ID = '33333333-3333-3333-3333-333333333333';
 const VICTIM_OWNER_ID = '99999999-9999-9999-9999-999999999999';
 const PET_ID = '22222222-2222-2222-2222-222222222222';
 const CLINIC_ID = '11111111-1111-1111-1111-111111111111';
+const DERIVED_CLINIC_ID = '44444444-4444-4444-4444-444444444444';
 const VALID = {
   clinic_id: CLINIC_ID,
   appointment_date: '2026-08-01',
@@ -48,6 +50,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   ({ default: SchedulingService } = await import('../services/scheduling.service.js'));
   SchedulingService.petBelongsToOwner.mockResolvedValue(true);
+  SchedulingService.getPetOwnerClinicId.mockResolvedValue(DERIVED_CLINIC_ID);
   const { default: schedulingRoutes } = await import('../routes/private/scheduling.routes.js');
   app = express();
   app.use(express.json());
@@ -83,6 +86,32 @@ describe('#3 — createScheduling bind do petOwner', () => {
       petId: PET_ID,
       petOwnerId: OWNER_ID,
     });
+  });
+
+  it('deriva clinic_id do tutor e IGNORA o clinic_id do body', async () => {
+    const res = await httpRequest(app, {
+      method: 'POST',
+      path: '/api/scheduling',
+      token: petOwnerToken({ id: OWNER_ID }),
+      body: { ...VALID, clinic_id: CLINIC_ID },
+    });
+    expect(res.status).toBe(201);
+    const arg = SchedulingService.createScheduling.mock.calls[0][0].schedulingData;
+    expect(arg[0].clinic_id).toBe(DERIVED_CLINIC_ID);
+    expect(arg[0].clinic_id).not.toBe(CLINIC_ID);
+    expect(SchedulingService.getPetOwnerClinicId).toHaveBeenCalledWith({ petOwnerId: OWNER_ID });
+  });
+
+  it('403 quando o tutor não tem clínica associada', async () => {
+    SchedulingService.getPetOwnerClinicId.mockResolvedValueOnce(null);
+    const res = await httpRequest(app, {
+      method: 'POST',
+      path: '/api/scheduling',
+      token: petOwnerToken({ id: OWNER_ID }),
+      body: { ...VALID },
+    });
+    expect(res.status).toBe(403);
+    expect(SchedulingService.createScheduling).not.toHaveBeenCalled();
   });
 
   it('redige a resposta do petOwner (sem email/phone)', async () => {

--- a/src/api/__tests__/scheduling-repo-by-pet.test.js
+++ b/src/api/__tests__/scheduling-repo-by-pet.test.js
@@ -1,0 +1,52 @@
+// H-2 #4 (camada repo) — getSchedulingsByPet monta o filtro s.pet_owner_id
+// quando petOwnerId é passado, com placeholders na ordem certa. pgQuery é
+// mockado (sem DB): asseguramos SQL + params.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../config/postgres.js', () => ({
+  pgQuery: vi.fn(async () => ({ rows: [] })),
+  pgPool: { query: vi.fn(), connect: vi.fn() },
+}));
+
+import SchedulingRepository from '../repositories/scheduling.repository.js';
+import { pgQuery } from '../../config/postgres.js';
+
+const lastCall = () => pgQuery.mock.calls[pgQuery.mock.calls.length - 1];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('#4 — repo getSchedulingsByPet', () => {
+  it('SEM petOwnerId: nenhum filtro de dono, params = [petId]', async () => {
+    await SchedulingRepository.getSchedulingsByPet({ petId: 'PET1' });
+    const [sql, params] = lastCall();
+    expect(sql).not.toContain('s.pet_owner_id = $');
+    expect(params).toEqual(['PET1']);
+  });
+
+  it('COM petOwnerId: filtro s.pet_owner_id = $2, params = [petId, ownerId]', async () => {
+    await SchedulingRepository.getSchedulingsByPet({ petId: 'PET1', petOwnerId: 'OWNER1' });
+    const [sql, params] = lastCall();
+    expect(sql).toContain('s.pet_owner_id = $2');
+    expect(params).toEqual(['PET1', 'OWNER1']);
+  });
+
+  it('COM petOwnerId + date: placeholders na ordem $1/$2/$3', async () => {
+    await SchedulingRepository.getSchedulingsByPet({
+      petId: 'PET1',
+      petOwnerId: 'OWNER1',
+      date: '2026-08-01',
+    });
+    const [sql, params] = lastCall();
+    expect(sql).toContain('s.pet_owner_id = $2');
+    expect(sql).toContain('s.scheduled_date::date = $3');
+    expect(params).toEqual(['PET1', 'OWNER1', '2026-08-01']);
+  });
+
+  it('SEM petOwnerId + date: date cai em $2', async () => {
+    await SchedulingRepository.getSchedulingsByPet({ petId: 'PET1', date: '2026-08-01' });
+    const [sql, params] = lastCall();
+    expect(sql).not.toContain('s.pet_owner_id = $');
+    expect(sql).toContain('s.scheduled_date::date = $2');
+    expect(params).toEqual(['PET1', '2026-08-01']);
+  });
+});

--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -1,6 +1,9 @@
 import SchedulingService from '../services/scheduling.service.js';
 import MerchantSchedulingAgentService from '../services/merchant-scheduling-agent.service.js';
-import { validateSchedulingUpdate } from '../validators/scheduling.validations.js';
+import {
+  validateSchedulingCreate,
+  validateSchedulingUpdate,
+} from '../validators/scheduling.validations.js';
 import {
   redactAppointmentForClinic,
   redactAppointmentsForClinic,
@@ -13,10 +16,11 @@ const getRoleString = (req) => {
   return raw?.role || raw?.name || null;
 };
 
-const getClinicId = (req) =>
-  req?.user?.clinic_id || req?.user?.role?.clinic_id || null;
+const getClinicId = (req) => req?.user?.clinic_id || req?.user?.role?.clinic_id || null;
 
 const isClinicRole = (req) => getRoleString(req) === 'clinic';
+
+const isPetOwnerRole = (req) => getRoleString(req) === 'petOwner';
 
 const actorOf = (req) => {
   if (!req?.user) return 'backend_admin';
@@ -67,12 +71,60 @@ const createScheduling = async (req, res) => {
         pet_owner_id: null,
         user_phone: null,
       }));
+    } else if (isPetOwnerRole(req)) {
+      // Anti-bypass: role petOwner só agenda pra SI mesmo. pet_owner_id é SEMPRE
+      // o id do JWT (nunca do body — senão vira oráculo de PII: informar o id da
+      // vítima faz o JOIN devolver email/nome dela). pet_id precisa ser um pet do
+      // próprio tutor (M:M pet_owner_pets). user_phone e campos de clínica-externa
+      // são zerados. Valida o body com Joi antes de tocar o service.
+      const ownerId = req.user.id;
+      const sanitized = [];
+      for (const raw of body) {
+        const candidate = {
+          ...raw,
+          pet_owner_id: ownerId,
+          user_phone: null,
+          pet_ids: null,
+          external_pet_id: null,
+          external_contact_id: null,
+        };
+        const { error, value } = validateSchedulingCreate(candidate);
+        if (error) {
+          return res.status(400).json({
+            code: 'VALIDATION_ERROR',
+            error: error.details.map((d) => d.message),
+          });
+        }
+        // Joi .or aceita external_pet_id:null como "presente" e não exige pet_id —
+        // por isso o check explícito aqui.
+        if (!value.pet_id) {
+          return res.status(400).json({
+            code: 'VALIDATION_ERROR',
+            message: 'pet_id é obrigatório',
+          });
+        }
+        const owns = await SchedulingService.petBelongsToOwner({
+          petId: value.pet_id,
+          petOwnerId: ownerId,
+        });
+        if (!owns) {
+          return res.status(403).json({
+            code: 'FORBIDDEN',
+            message: 'Você não tem permissão para agendar para este pet',
+          });
+        }
+        sanitized.push(value);
+      }
+      body = sanitized;
     }
 
     const created = await SchedulingService.createScheduling({ schedulingData: body });
+    // clinic e petOwner recebem payload redigido (sem user_phone/email). Pra
+    // petOwner é defesa em profundidade — o pet_owner_id já foi forçado pra ele.
+    const shouldRedact = isClinicRole(req) || isPetOwnerRole(req);
     return res.status(201).json({
       code: 'SCHEDULING_CREATED',
-      data: isClinicRole(req) ? redactAppointmentsForClinic(created) : created,
+      data: shouldRedact ? redactAppointmentsForClinic(created) : created,
     });
   } catch (error) {
     return handleError(res, error, {
@@ -123,9 +175,7 @@ const getSchedulingsByClinic = async (req, res) => {
       status,
     });
 
-    const payload = isClinicRole(req)
-      ? redactAppointmentsForClinic(schedulings)
-      : schedulings;
+    const payload = isClinicRole(req) ? redactAppointmentsForClinic(schedulings) : schedulings;
 
     return res.status(200).json({
       code: 'CLINIC_SCHEDULINGS_FETCHED',

--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -241,7 +241,15 @@ const getSchedulingsByPet = async (req, res) => {
     // só olhava schedulings[0].pet_owner_id — bastava a sessão mais antiga do pet
     // ser do atacante (pet co-tutelado via guardian) pra passar e vazar user_phone
     // + email das sessões de OUTROS tutores. Filtrar na query elimina o índice-0.
-    const petOwnerId = getRoleString(req) === 'petOwner' ? req.user.id : undefined;
+    // Defesa em profundidade: petOwner sem id no token NÃO cai no caminho unscoped
+    // (que devolveria todas as sessões do pet) — nega.
+    if (isPetOwnerRole(req) && !req.user.id) {
+      return res.status(403).json({
+        code: 'FORBIDDEN',
+        message: 'Token de tutor sem identificação',
+      });
+    }
+    const petOwnerId = isPetOwnerRole(req) ? req.user.id : undefined;
 
     const schedulings = await SchedulingService.getSchedulingsByPet({
       petId,

--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -225,22 +225,19 @@ const getSchedulingsByPet = async (req, res) => {
   try {
     const { petId } = req.params;
     const { date, status } = req.query;
+
+    // Role petOwner: escopar no repo por pet_owner_id = req.user.id. O guard antigo
+    // só olhava schedulings[0].pet_owner_id — bastava a sessão mais antiga do pet
+    // ser do atacante (pet co-tutelado via guardian) pra passar e vazar user_phone
+    // + email das sessões de OUTROS tutores. Filtrar na query elimina o índice-0.
+    const petOwnerId = getRoleString(req) === 'petOwner' ? req.user.id : undefined;
+
     const schedulings = await SchedulingService.getSchedulingsByPet({
       petId,
       date,
       status,
+      petOwnerId,
     });
-
-    if (
-      getRoleString(req) === 'petOwner' &&
-      schedulings.length > 0 &&
-      schedulings[0].pet_owner_id !== req.user.id
-    ) {
-      return res.status(403).json({
-        code: 'FORBIDDEN',
-        message: 'Você não tem permissão para acessar agendamentos de pets que não são seus',
-      });
-    }
 
     return res.status(200).json({
       code: 'PET_SCHEDULINGS_FETCHED',

--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -74,14 +74,25 @@ const createScheduling = async (req, res) => {
     } else if (isPetOwnerRole(req)) {
       // Anti-bypass: role petOwner só agenda pra SI mesmo. pet_owner_id é SEMPRE
       // o id do JWT (nunca do body — senão vira oráculo de PII: informar o id da
-      // vítima faz o JOIN devolver email/nome dela). pet_id precisa ser um pet do
-      // próprio tutor (M:M pet_owner_pets). user_phone e campos de clínica-externa
-      // são zerados. Valida o body com Joi antes de tocar o service.
+      // vítima faz o JOIN devolver email/nome dela). clinic_id é derivado do
+      // registro do tutor (NUNCA do body — senão o tutor pendura agendamento
+      // CONFIRMED em qualquer clínica). pet_id precisa ser um pet do próprio tutor
+      // (M:M pet_owner_pets). user_phone e campos de clínica-externa são zerados.
       const ownerId = req.user.id;
+      const ownerClinicId = await SchedulingService.getPetOwnerClinicId({
+        petOwnerId: ownerId,
+      });
+      if (!ownerClinicId) {
+        return res.status(403).json({
+          code: 'FORBIDDEN',
+          message: 'Tutor sem clínica associada não pode criar agendamento',
+        });
+      }
       const sanitized = [];
       for (const raw of body) {
         const candidate = {
           ...raw,
+          clinic_id: ownerClinicId,
           pet_owner_id: ownerId,
           user_phone: null,
           pet_ids: null,

--- a/src/api/middlewares/auth.middleware.js
+++ b/src/api/middlewares/auth.middleware.js
@@ -57,36 +57,4 @@ const checkRole = (allowedRoles) => {
   };
 };
 
-const routeGuard = (allowedTypes) => {
-  return (req, res, next) => {
-    try {
-      const userRole = req.user.role?.toLowerCase();
-
-      if (
-        allowedTypes === 'veterinary' &&
-        !['veterinary', 'admin', 'superadmin'].includes(userRole)
-      ) {
-        return res.status(403).json({
-          code: 'ACCESS_DENIED',
-          message: 'Esta rota é exclusiva para veterinários',
-        });
-      }
-
-      if (allowedTypes === 'petowner' && userRole !== 'petowner') {
-        return res.status(403).json({
-          code: 'ACCESS_DENIED',
-          message: 'Esta rota é exclusiva para tutores',
-        });
-      }
-
-      next();
-    } catch (error) {
-      return res.status(500).json({
-        code: 'GUARD_ERROR',
-        message: 'Erro ao verificar permissões de rota',
-      });
-    }
-  };
-};
-
-export { verifyToken, checkRole, routeGuard };
+export { verifyToken, checkRole };

--- a/src/api/repositories/scheduling.repository.js
+++ b/src/api/repositories/scheduling.repository.js
@@ -108,6 +108,18 @@ const createScheduling = async ({ schedulingData, client = null }) => {
   return getSchedulingById({ id: insertedId, client: runner });
 };
 
+// Ownership check pra role petOwner: o pet precisa estar vinculado ao tutor na
+// M:M pet_owner_pets. Usado por createScheduling pra impedir que um tutor agende
+// (e vaze PII) pendurando o agendamento num pet que não é dele.
+const petBelongsToOwner = async ({ petId, petOwnerId }) => {
+  if (!petId || !petOwnerId) return false;
+  const result = await pgQuery(
+    `SELECT 1 FROM pet_owner_pets WHERE pet_id = $1 AND pet_owner_id = $2 LIMIT 1`,
+    [petId, petOwnerId],
+  );
+  return result.rowCount > 0;
+};
+
 const getSchedulingById = async ({ id, client = null }) => {
   const runner = client ?? pgPool;
   const result = await runner.query(`${BASE_SELECT} WHERE s.id = $1 LIMIT 1`, [id]);
@@ -130,11 +142,7 @@ const getAllSchedulings = async ({ date, status } = {}) => {
 };
 
 const getSchedulingsByClinic = async ({ clinicId, date, status }) => {
-  const { filters, values, nextIndex } = buildDateAndStatusFilter(
-    { date, status },
-    's',
-    2,
-  );
+  const { filters, values, nextIndex } = buildDateAndStatusFilter({ date, status }, 's', 2);
   values.unshift(clinicId);
   const where = `WHERE s.clinic_id = $1${filters.length ? ` AND ${filters.join(' AND ')}` : ''}`;
   const result = await pgQuery(
@@ -160,7 +168,9 @@ const getSchedulingsByPetOwner = async ({ petOwnerId, date, status }) => {
 const getSchedulingsByPet = async ({ petId, date, status }) => {
   const { filters, values } = buildDateAndStatusFilter({ date, status }, 's', 2);
   values.unshift(petId);
-  const where = `WHERE (s.pet_id = $1 OR $1 = ANY(s.pet_ids))${filters.length ? ` AND ${filters.join(' AND ')}` : ''}`;
+  const where = `WHERE (s.pet_id = $1 OR $1 = ANY(s.pet_ids))${
+    filters.length ? ` AND ${filters.join(' AND ')}` : ''
+  }`;
   const result = await pgQuery(
     `${BASE_SELECT} ${where} ORDER BY s.scheduled_date ASC NULLS LAST`,
     values,
@@ -266,10 +276,9 @@ const confirmScheduling = async ({ id, actor = 'backend_admin' }) => {
 };
 
 const deleteScheduling = async ({ id }) => {
-  const existing = await pgQuery(
-    `SELECT source FROM scheduling_sessions WHERE id = $1 LIMIT 1`,
-    [id],
-  );
+  const existing = await pgQuery(`SELECT source FROM scheduling_sessions WHERE id = $1 LIMIT 1`, [
+    id,
+  ]);
   if (existing.rowCount === 0) {
     const error = new Error('Scheduling not found');
     error.code = 'NOT_FOUND';
@@ -298,7 +307,9 @@ function resolveScheduledDate(appointmentDate, startTime) {
         appointmentDate instanceof Date
           ? appointmentDate.toISOString().slice(0, 10)
           : String(appointmentDate).slice(0, 10);
-      return new Date(`${datePart}T${startTime.length === 5 ? `${startTime}:00` : startTime}-03:00`);
+      return new Date(
+        `${datePart}T${startTime.length === 5 ? `${startTime}:00` : startTime}-03:00`,
+      );
     }
   }
 
@@ -313,6 +324,7 @@ function resolveScheduledDate(appointmentDate, startTime) {
 
 export default {
   createScheduling,
+  petBelongsToOwner,
   getSchedulingById,
   getAllSchedulings,
   getSchedulingsByClinic,

--- a/src/api/repositories/scheduling.repository.js
+++ b/src/api/repositories/scheduling.repository.js
@@ -165,14 +165,26 @@ const getSchedulingsByPetOwner = async ({ petOwnerId, date, status }) => {
   return mapRows(result.rows);
 };
 
-const getSchedulingsByPet = async ({ petId, date, status }) => {
-  const { filters, values } = buildDateAndStatusFilter({ date, status }, 's', 2);
-  values.unshift(petId);
-  const where = `WHERE (s.pet_id = $1 OR $1 = ANY(s.pet_ids))${
-    filters.length ? ` AND ${filters.join(' AND ')}` : ''
-  }`;
+const getSchedulingsByPet = async ({ petId, date, status, petOwnerId = null }) => {
+  const values = [petId];
+  const conditions = ['(s.pet_id = $1 OR $1 = ANY(s.pet_ids))'];
+  let idx = 2;
+
+  // Escopo por dono (role petOwner): só sessões onde o requester é o pet_owner_id.
+  // Sem isso, um pet co-tutelado (guardian) devolve sessões — e PII — de outro
+  // tutor. Admin/superAdmin chamam sem petOwnerId e continuam vendo tudo.
+  if (petOwnerId) {
+    values.push(petOwnerId);
+    conditions.push(`s.pet_owner_id = $${idx}`);
+    idx += 1;
+  }
+
+  const { filters, values: dsValues } = buildDateAndStatusFilter({ date, status }, 's', idx);
+  values.push(...dsValues);
+  conditions.push(...filters);
+
   const result = await pgQuery(
-    `${BASE_SELECT} ${where} ORDER BY s.scheduled_date ASC NULLS LAST`,
+    `${BASE_SELECT} WHERE ${conditions.join(' AND ')} ORDER BY s.scheduled_date ASC NULLS LAST`,
     values,
   );
   return mapRows(result.rows);

--- a/src/api/repositories/scheduling.repository.js
+++ b/src/api/repositories/scheduling.repository.js
@@ -120,6 +120,17 @@ const petBelongsToOwner = async ({ petId, petOwnerId }) => {
   return result.rowCount > 0;
 };
 
+// Clínica-casa do tutor. createScheduling do petOwner deriva o clinic_id daqui —
+// NUNCA do body — pra impedir que um tutor pendure agendamento (CONFIRMED) em
+// qualquer clínica. pet_owners.clinic_id é NOT NULL.
+const getPetOwnerClinicId = async ({ petOwnerId }) => {
+  if (!petOwnerId) return null;
+  const result = await pgQuery(`SELECT clinic_id FROM pet_owners WHERE id = $1 LIMIT 1`, [
+    petOwnerId,
+  ]);
+  return result.rows[0]?.clinic_id ?? null;
+};
+
 const getSchedulingById = async ({ id, client = null }) => {
   const runner = client ?? pgPool;
   const result = await runner.query(`${BASE_SELECT} WHERE s.id = $1 LIMIT 1`, [id]);
@@ -337,6 +348,7 @@ function resolveScheduledDate(appointmentDate, startTime) {
 export default {
   createScheduling,
   petBelongsToOwner,
+  getPetOwnerClinicId,
   getSchedulingById,
   getAllSchedulings,
   getSchedulingsByClinic,

--- a/src/api/routes/private/pet-owners.routes.js
+++ b/src/api/routes/private/pet-owners.routes.js
@@ -1,19 +1,28 @@
 import { Router } from 'express';
 import PetOwnerController from '../../controllers/pet-owner.controller.js';
-import { verifyToken } from '../../middlewares/auth.middleware.js';
+import { verifyToken, checkRole } from '../../middlewares/auth.middleware.js';
 
 const router = Router();
 
-router.post('/', verifyToken, PetOwnerController.createPetOwner);
+// /pet-owner é superfície Latta (painel admin interno) — o repo devolve o
+// registro COMPLETO e NÃO redacted (name, email, cell_phone, cpf, rg,
+// date_of_birth, address_*, emergency_contact_*). Role 'clinic' NUNCA pode
+// entrar aqui: um token de clínica passa no verifyToken e leria/mutaria PII de
+// tutor em claro, furando o appointment-redactor. Clientes próprios da clínica
+// vivem em external_contacts via /clinic/external-* (rota corretamente guardada).
+// Convenção alinhada com as rotas irmãs /pet e /users (['admin','superAdmin']).
+const ADMIN_ONLY = checkRole(['admin', 'superAdmin']);
 
-router.get('/', verifyToken, PetOwnerController.getAllPetOwners);
+router.post('/', verifyToken, ADMIN_ONLY, PetOwnerController.createPetOwner);
 
-router.get('/:id', verifyToken, PetOwnerController.getPetOwnerById);
+router.get('/', verifyToken, ADMIN_ONLY, PetOwnerController.getAllPetOwners);
 
-router.put('/:id', verifyToken, PetOwnerController.updatePetOwner);
+router.get('/:id', verifyToken, ADMIN_ONLY, PetOwnerController.getPetOwnerById);
 
-router.delete('/:id', verifyToken, PetOwnerController.deletePetOwner);
+router.put('/:id', verifyToken, ADMIN_ONLY, PetOwnerController.updatePetOwner);
 
-router.get('/search/:term', verifyToken, PetOwnerController.searchPetOwners);
+router.delete('/:id', verifyToken, ADMIN_ONLY, PetOwnerController.deletePetOwner);
+
+router.get('/search/:term', verifyToken, ADMIN_ONLY, PetOwnerController.searchPetOwners);
 
 export default router;

--- a/src/api/services/scheduling.service.js
+++ b/src/api/services/scheduling.service.js
@@ -144,8 +144,8 @@ const getSchedulingsByClinic = async ({ clinicId, date, status }) =>
 const getSchedulingsByPetOwner = async ({ petOwnerId, date, status }) =>
   SchedulingRepository.getSchedulingsByPetOwner({ petOwnerId, date, status });
 
-const getSchedulingsByPet = async ({ petId, date, status }) =>
-  SchedulingRepository.getSchedulingsByPet({ petId, date, status });
+const getSchedulingsByPet = async ({ petId, date, status, petOwnerId }) =>
+  SchedulingRepository.getSchedulingsByPet({ petId, date, status, petOwnerId });
 
 const getSchedulingById = async ({ id }) => SchedulingRepository.getSchedulingById({ id });
 

--- a/src/api/services/scheduling.service.js
+++ b/src/api/services/scheduling.service.js
@@ -14,9 +14,7 @@ const generateRecurrentSchedulings = (scheduling) => {
   const { frequency, endCondition } = scheduling;
   const baseDate = DateTime.fromISO(scheduling.appointment_date);
   const baseStartTime = DateTime.fromSQL(scheduling.start_time);
-  const baseEndTime = scheduling.end_time
-    ? DateTime.fromSQL(scheduling.end_time)
-    : baseStartTime;
+  const baseEndTime = scheduling.end_time ? DateTime.fromSQL(scheduling.end_time) : baseStartTime;
 
   let endDate = baseDate;
   if (endCondition?.type === 'after') {
@@ -91,7 +89,9 @@ const createScheduling = async ({ schedulingData }) => {
   for (const item of allSchedulings) {
     if (!item.external_pet_id && !item.external_contact_id) continue;
     if (!item.clinic_id) {
-      throw new Error('clinic_id obrigatório quando external_pet_id ou external_contact_id presente');
+      throw new Error(
+        'clinic_id obrigatório quando external_pet_id ou external_contact_id presente',
+      );
     }
     if (item.external_pet_id) {
       await ClinicExternalRepository.assertExternalPetBelongsToClinic({
@@ -132,6 +132,9 @@ const createScheduling = async ({ schedulingData }) => {
   }
 };
 
+const petBelongsToOwner = async ({ petId, petOwnerId }) =>
+  SchedulingRepository.petBelongsToOwner({ petId, petOwnerId });
+
 const getAllSchedulings = async ({ date, status }) =>
   SchedulingRepository.getAllSchedulings({ date, status });
 
@@ -159,6 +162,7 @@ const deleteScheduling = async ({ id }) => SchedulingRepository.deleteScheduling
 
 export default {
   createScheduling,
+  petBelongsToOwner,
   getAllSchedulings,
   getSchedulingsByClinic,
   getSchedulingsByPetOwner,

--- a/src/api/services/scheduling.service.js
+++ b/src/api/services/scheduling.service.js
@@ -135,6 +135,9 @@ const createScheduling = async ({ schedulingData }) => {
 const petBelongsToOwner = async ({ petId, petOwnerId }) =>
   SchedulingRepository.petBelongsToOwner({ petId, petOwnerId });
 
+const getPetOwnerClinicId = async ({ petOwnerId }) =>
+  SchedulingRepository.getPetOwnerClinicId({ petOwnerId });
+
 const getAllSchedulings = async ({ date, status }) =>
   SchedulingRepository.getAllSchedulings({ date, status });
 
@@ -163,6 +166,7 @@ const deleteScheduling = async ({ id }) => SchedulingRepository.deleteScheduling
 export default {
   createScheduling,
   petBelongsToOwner,
+  getPetOwnerClinicId,
   getAllSchedulings,
   getSchedulingsByClinic,
   getSchedulingsByPetOwner,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Suite de authz do painel da clínica (H-2). Testes hermeticos: mockam a camada
+// de serviço/DB e exercitam apenas os guards de role + a lógica de bind/redação
+// dos controllers. Não tocam Postgres nem rede.
+export default defineConfig({
+  test: {
+    include: ['src/api/__tests__/**/*.test.js'],
+    environment: 'node',
+    globals: false,
+  },
+});


### PR DESCRIPTION
## H-2 — Hardening de authz do portal da clínica

Fecha os 5 achados confirmados na auditoria adversarial de authz (2026-07-02) sobre a main pós grupo H (#74). Spec: `docs/issues/clinic-portal-authz-hardening/SPEC.md` (repo principal). Backend-only, sem mudança de frontend.

Contexto: o grupo H blindou `scheduling.routes.js` + construiu o `appointment-redactor`, mas o autorreview só olhou o que ele tocou. A auditoria independente pegou uma família de rotas inteira — `/pet-owner/*` — sem nenhum guard de role.

### Achados corrigidos (1 commit por finding)

- **#1/#2 — P1 — `/pet-owner/*` sem `checkRole`** (`0a51173`)
  As 6 rotas tinham só `verifyToken`. Um token de **clínica** válido passava e lia/mutava o registro **completo e não-redacted** do tutor (`name, email, cell_phone, cpf, rg, date_of_birth, address_*, emergency_contact_*`), furando o redactor. Adiciona `checkRole(['admin','superAdmin'])` — alinhado com as rotas irmãs `/pet` e `/users`.

- **#3 — P2 — `createScheduling` não vinculava o petOwner** (`f2e842d` + `82d4f1e`)
  A role `petOwner` mandava o body cru pro service (o anti-bypass só rodava pra clinic): dava pra (a) forjar agendamentos `CONFIRMED` em qualquer clínica e (b) informar o `pet_owner_id` da vítima e receber email+nome dela na resposta (oráculo de PII). Agora, pra petOwner: `pet_owner_id` forçado = `req.user.id`; `clinic_id` **derivado** do registro do tutor (`pet_owners.clinic_id`, nunca do body); `pet_id` obrigatório e validado contra `pet_owner_pets` (403 se não for pet do tutor); `user_phone`/external_* zerados; Joi no body; resposta redigida.

- **#4 — P2 — `getSchedulingsByPet` validava só `schedulings[0]`** (`c957ff0` + `dd4790c`)
  O repo retornava todas as sessões do pet e o guard só olhava a mais antiga — um pet co-tutelado (guardian) vazava `user_phone`+email de outros tutores. Agora a query é escopada no repo por `pet_owner_id = req.user.id` pra petOwner. Defense-in-depth: petOwner sem `id` no token → 403 (não cai no caminho unscoped).

- **#5 — P3 — `routeGuard` dead code quebrado** (`10fea7a`)
  `req.user.role?.toLowerCase()` num role-objeto → TypeError → 500 fail-closed. Não estava plugado em nenhuma rota. **Removido** (o role-gating é do `checkRole`, que trata o role-objeto correto).

### Decisão de role list (`/pet-owner`)
Investiguei os consumidores: `/pet-owner` é chamado **só pelo painel admin** (`PetCard`, `PetTabHeader`, `SchedulingModal` — todas `pages/private/`). `petOwner` no frontend só acessa `/home`+`/pets`; `clinic` só `/scheduling`+`/profile` e cria agendamentos via **external_contacts** (`/clinic/external-*`), não `/pet-owner`. Logo `['admin','superAdmin']` é a lista certa (a clínica **nunca** pode ver o `/pet-owner` cru — a spec é explícita).

### Notas de comportamento (esperadas, não regressões)
- **clinic → 403 em `/pet-owner`**: é o próprio fix. Cliente da clínica vive em `external_contacts`.
- **petOwner em `/pets` → `getPetOwnerById` agora 403** (antes **500**): o controller escopa por `clinic_id` (undefined pra petOwner → Sequelize lança) — self-access já não funcionava; nenhum fluxo que funcionava quebra.
- **admin/superAdmin**: acesso ao `/pet-owner` depende do JWT ter `clinic_id` (comportamento **pré-existente** do controller, não alterado aqui).

### Bugs pré-existentes descobertos (fora de escopo — NÃO tocados)
- `pet-owner.repository.js` `searchPetOwners` usa `Op.or`/`Op.iLike` sem importar `Op` → `/pet-owner/search/:term` sempre 500 (ReferenceError). Independe de authz.
- `pet-owner.controller.js` `createPetOwner` grava `clinic_id` do JWT numa coluna `NOT NULL`: admin sem `clinic_id` → violação. Comportamento pré-existente do controller.

Reporto pra triagem separada — não entram neste PR de segurança pra manter o escopo nos 5 findings.

### Testes
Harness vitest novo (hermético: mocka service/DB, exercita guards + lógica de bind/scope/redação; sem Postgres/rede). **22 testes, 5 arquivos, todos passando** (`npm test`):
- `pet-owner-authz` — clínica→403, petOwner→403, sem token→401, admin/superAdmin→200 (6 rotas).
- `scheduling-create-authz` — pet de terceiro→403, bind de `pet_owner_id`, `clinic_id` derivado ignora o body, sem clínica→403, sem `pet_id`→400, resposta redigida, admin passa direto.
- `scheduling-by-pet-authz` + `scheduling-repo-by-pet` — controller passa `petOwnerId` correto, clinic→403, petOwner sem id→403, SQL escopa com placeholders na ordem certa.
- `auth-middleware` — `routeGuard` não exportado, `checkRole` trata role-objeto (403, não 500).

> Revisão adicional: rodei `/code-review high` no diff antes do PR. Os achados acionáveis (resíduo do `clinic_id` no #3 e defense-in-depth do #4) foram incorporados nos commits `82d4f1e`/`dd4790c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
