### PR TITLE
fix(backend): copy de→para dos reasons de cancel/no-show/remarcação (F1 backend)

### DIFF
--- a/src/api/controllers/scheduling.controller.js
+++ b/src/api/controllers/scheduling.controller.js
@@ -344,7 +344,7 @@ const cancelScheduling = async (req, res) => {
       }
     }
 
-    const reason = req.body?.reason || 'cancelado pela clinica via painel';
+    const reason = req.body?.reason || 'o estabelecimento cancelou pelo painel';
 
     // Latta (source=latta): chama EF merchant-scheduling-agent que dispara
     // template pro tutor + transita state. External (source=external): UPDATE
@@ -380,7 +380,7 @@ const noShowScheduling = async (req, res) => {
       }
     }
 
-    const reason = req.body?.reason || 'tutor nao compareceu';
+    const reason = req.body?.reason || 'você não compareceu';
 
     if (scheduling.source === 'latta') {
       await MerchantSchedulingAgentService.noShowByMerchant({ sessionId: id, reason });
@@ -438,7 +438,7 @@ const rescheduleScheduling = async (req, res) => {
         sessionId: id,
         newScheduledDate: new_scheduled_date,
         newScheduledService: new_scheduled_service,
-        reason: reason || 'remarcado pela clinica via painel',
+        reason: reason || 'o estabelecimento remarcou pelo painel',
       });
     } else {
       // External: o repo só grava a data via resolveScheduledDate(appointment_date,


### PR DESCRIPTION
Item de **backend** do Grupo F1 (de→para de copy) da manutenção do scheduling. Os outros itens de F1 foram na EF (repo Latta, PR #582); este é o `web/backend`.

Os defaults de `reason` no cancel/no-show/reschedule pelo painel da clínica são renderizados pro TUTOR como "Motivo informado: {reason}" — hoje com jargão interno/inglês/3ª pessoa:
- `scheduling.controller.js` cancel: "cancelado pela clinica via painel" → **"o estabelecimento cancelou pelo painel"**
- no-show: "tutor nao compareceu" → **"você não compareceu"** (2ª pessoa, acentuado)
- reschedule: "remarcado pela clinica via painel" → **"o estabelecimento remarcou pelo painel"**

Só string literals; sem mudança de lógica. Deploy do backend (EC2) segue o fluxo do time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)