### PR TITLE
fix(backend): busca de contatos por nome/telefone estava sempre falhando

### DIFF
--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -959,15 +959,39 @@ const searchContacts = async ({
           'DESC',
         ],
         ['updated_at', 'DESC'],
-        [{ model: ChatHistory, as: 'chatHistory' }, 'timestamp', 'DESC'],
+        // NAO ordenar por coluna do include (era `[{model: ChatHistory}, 'timestamp']`):
+        // como ha `limit` no parent, o Sequelize move os contatos pra uma subconsulta e o
+        // ORDER BY externo passa a referenciar "chatHistory", que nao existe naquele
+        // escopo -> o Postgres derruba a query inteira com
+        // `missing FROM-clause entry for table "chatHistory"`. A busca por nome/telefone
+        // NUNCA retornou nada por causa disso: o controller devolvia erro e o frontend,
+        // que trata falha como lista vazia, mostrava "Nenhuma conversa encontrada".
+        // getAllContactsWithMessages ja tinha caido nessa armadilha e ordena so por
+        // subquery correlacionada — aqui seguimos o mesmo padrao. A ordem das mensagens
+        // dentro de cada contato e resolvida no cliente (sortChatHistory).
       ],
       include: [
         {
           model: ChatHistory,
           as: 'chatHistory',
-          where: chatHistoryWhere,
           required: false,
-          limit: 20,
+          // Limite por contato via subquery correlacionada, e nao pelo `limit` do
+          // Sequelize: `limit` dentro de include hasMany so funciona com
+          // `separate: true` (N+1 queries) e conflita com o limit do parent. Mesmo
+          // padrao de getAllContactsWithMessages.
+          where: {
+            ...chatHistoryWhere,
+            id: {
+              [Op.in]: Sequelize.literal(`(
+                SELECT ch.id
+                FROM chat_history ch
+                WHERE ch.contact_id = "Contact".id
+                ${shouldFilterLatta ? `AND ch.path != 'latta'` : ''}
+                ORDER BY ch.timestamp DESC
+                LIMIT 20
+              )`),
+            },
+          },
           attributes: [
             'id',
             [Sequelize.fn('LEFT', Sequelize.col('chatHistory.message'), 8000), 'message'],


### PR DESCRIPTION
## O bug

A busca de contatos na mensageria (`/chat-history/messages/searchContacts`) **nunca retornou resultado**. O Postgres derrubava a query inteira com:

```
missing FROM-clause entry for table "chatHistory"
```

## Causa raiz

O `findAll` do `searchContacts` ordenava por uma **coluna do include** — `[{ model: ChatHistory, as: 'chatHistory' }, 'timestamp', 'DESC']` — e usava o `limit: 20` do Sequelize dentro de um include `hasMany`.

Como existe `limit` no parent, o Sequelize move os contatos pra uma subconsulta. O `ORDER BY` externo passa entao a referenciar `"chatHistory"`, que nao existe naquele escopo — e o Postgres rejeita a query inteira.

O `getAllContactsWithMessages` **ja tinha caido nessa mesma armadilha**: o comentario na linha 312 diz literalmente _"Nao usar ordem por coluna do include"_. Ele resolveu com subquery correlacionada. O `searchContacts` ficou pra tras.

## Por que ninguem percebeu

O frontend trata falha de request como lista vazia (`useContacts.js`: `catch` -> `setContacts([])`). O operador via **"Nenhuma conversa encontrada"** em vez de um erro — parecia que o contato e que nao existia. Descoberto quando o operador tentou buscar o proprio nome no painel e nao achou a propria conversa.

## O fix

Mesmo padrao que a lista ja usa:
- ordena **so** por subquery correlacionada (sem coluna de include);
- limita as mensagens por contato com `id IN (SELECT ... ORDER BY timestamp DESC LIMIT 20)` em vez do `limit` do Sequelize.

## Verificacao

Rodado contra o banco de producao (somente leitura), chamando o mesmo service que o endpoint chama:

| busca | antes | depois |
|---|---|---|
| `Lucas` | erro -> 0 | **2 resultados** |
| `Bergman` | erro -> 0 | **1 resultado** |
| `9192` (telefone) | erro -> 0 | **1 resultado** |

A busca por telefone usa o mesmo `findAll`, entao estava quebrada tambem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
