### PR TITLE
feat(mensageria): aba Testers + busca acha a whitelist + clinica em atendimento nao some

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -463,6 +463,62 @@ const getAllB2bContacts = async (req, res) => {
   }
 };
 
+const getAllTesterContacts = async (req, res) => {
+  try {
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 15;
+    const { id, role, environment } = req.user;
+
+    const responsibility = req.query.responsibility === 'true';
+    const unread = req.query.unread === 'true';
+    const tags = req?.query?.tags ? req.query.tags.split(',').filter((tag) => tag.trim()) : [];
+
+    const filters = { responsibility, unread, tags };
+
+    const result = await ChatService.getAllTesterContacts({
+      user_id: id,
+      role: role.role,
+      page,
+      limit,
+      filters,
+      environment: environment || 'prod',
+    });
+
+    return res.status(200).json({
+      code: 'TESTER_CONTACTS_RETRIEVED',
+      data: result.contacts,
+    });
+  } catch (error) {
+    console.error('Error retrieving tester contacts:', error);
+    return res.status(500).json({
+      code: 'TESTER_CONTACTS_RETRIEVAL_ERROR',
+      message: error.message,
+    });
+  }
+};
+
+const getTesterContactsCount = async (req, res) => {
+  try {
+    const { role, environment } = req.user;
+
+    const result = await ChatService.getTesterContactsCount({
+      role: role.role,
+      environment: environment || 'prod',
+    });
+
+    return res.status(200).json({
+      code: 'TESTER_CONTACTS_COUNT_RETRIEVED',
+      data: { count: result.count },
+    });
+  } catch (error) {
+    console.error('Error retrieving tester contacts count:', error);
+    return res.status(500).json({
+      code: 'TESTER_CONTACTS_COUNT_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getB2bContactsCount = async (req, res) => {
   try {
     const { role, environment } = req.user;
@@ -580,8 +636,10 @@ export default {
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getAllB2bContacts,
+  getAllTesterContacts,
   getTestContactsCount,
   getB2bContactsCount,
+  getTesterContactsCount,
   getInAttendanceContactsCount,
   markAsAnswered,
   getMessagesDaysSummary,

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -558,6 +558,10 @@ const getAllContactsWithMessages = async ({
   }
 };
 
+// Aba Luma. b2bFilter='none' de proposito: a Luma e' um recorte de ESTADO
+// (quem esta em atendimento humano), nao de populacao. Excluir clinicas aqui
+// abria um buraco — a aba B2B ja exclui quem esta em atendimento, entao uma
+// clinica sendo atendida nao aparecia em lugar nenhum do painel.
 const getAllContactsBeingAttended = async ({
   role,
   page = 1,
@@ -565,7 +569,7 @@ const getAllContactsBeingAttended = async ({
   user_id,
   filters = {},
   testFilter = 'exclude',
-  b2bFilter = 'exclude',
+  b2bFilter = 'none',
   environment = 'prod',
 }) => {
   try {
@@ -1961,11 +1965,12 @@ const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
 
 
 // Badge da aba Luma: conta o MESMO conjunto que getAllContactsBeingAttended
-// lista (em atendimento humano, com chat_history, fora do universo QA em prod).
+// lista (em atendimento humano, com chat_history, fora do universo QA em prod,
+// clinicas incluidas).
 const getInAttendanceContactsCount = async ({
   role,
   testFilter = 'exclude',
-  b2bFilter = 'exclude',
+  b2bFilter = 'none',
   environment = 'prod',
 } = {}) => {
   try {

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -92,6 +92,23 @@ const buildStagingEnvironmentCondition = (Op, environment) => {
   return { id: { [Op.notIn]: Sequelize.literal(QA_CONTACT_IDS_SUBQUERY) } };
 };
 
+// Environment na BUSCA — mais permissivo que o das abas, de proposito.
+// As abas sao listagens passivas: o operador nao pediu por ninguem, entao o
+// prod nao deve empurrar contato de QA pra ele. A busca e' o oposto — ele
+// digitou um nome/telefone especifico. Excluir a whitelist ali fazia buscar
+// "matheus" devolver "Nenhuma conversa encontrada" mesmo com a conversa
+// existindo, e a unica saida era o Debug Mode.
+//   - homolog: mostra APENAS o universo QA (igual as abas)
+//   - prod:    exclui so as personas SINTETICAS (range 5500000000XXX / marker
+//              test-persona|). A whitelist staging_users volta a ser
+//              encontravel — e' gente real, com conversa real.
+const buildSearchEnvironmentCondition = (Op, environment) => {
+  if (environment === 'homolog') {
+    return { id: { [Op.in]: Sequelize.literal(QA_CONTACT_IDS_SUBQUERY) } };
+  }
+  return { id: { [Op.notIn]: Sequelize.literal(TEST_CONTACT_IDS_SUBQUERY) } };
+};
+
 const RECENT_ORDERS_LIMIT = 10;
 const ORDER_LIST_ATTRS = [
   'id',
@@ -869,8 +886,9 @@ const searchContacts = async ({
     // Aplica os filtros adicionais (mesma lógica do getAllContacts)
     const additionalConditions = [];
 
-    // FILTRO DE ENVIRONMENT — ADR-0007 Fatia 7. Veja getAllContactsWithMessages.
-    const stagingEnvCondition = buildStagingEnvironmentCondition(Op, environment);
+    // FILTRO DE ENVIRONMENT — na busca, a whitelist E' encontravel em prod.
+    // Ver buildSearchEnvironmentCondition.
+    const stagingEnvCondition = buildSearchEnvironmentCondition(Op, environment);
     if (stagingEnvCondition) {
       additionalConditions.push(stagingEnvCondition);
     }

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -164,6 +164,7 @@ const buildContactScopeWhere = ({
   role,
   testFilter = 'exclude',
   b2bFilter = 'exclude',
+  stagingFilter = 'none',
   environment = 'prod',
   beingAttended = false,
 }) => {
@@ -171,6 +172,14 @@ const buildContactScopeWhere = ({
   const shouldFilterLatta = role !== 'admin' && role !== 'superAdmin';
   const testChatFilter = buildTestChatFilter(testFilter);
   const b2bChatFilter = buildB2bChatFilter(b2bFilter);
+
+  // Aba "Testers" (stagingFilter='only'): mostra os humanos reais da whitelist
+  // staging_users — hoje os socios testando em prod com o proprio numero.
+  // Eles sao invisiveis nas outras abas porque o universo QA e' excluido do
+  // prod, e ate agora so o Debug Mode os alcancava. Aqui a aba e' um recorte
+  // deliberado desse universo, entao NAO aplica o filtro de environment (que
+  // e' justamente quem os esconde) — ver mais abaixo.
+  const stagingOnly = stagingFilter === 'only';
 
   // Base: contatos que TEM pelo menos uma chat_history. Sem corte por
   // clinic_id — visao unificada (refactor 2026-05-08): so dois socios usam o
@@ -189,10 +198,11 @@ const buildContactScopeWhere = ({
 
   if (beingAttended) {
     scope.is_being_attended = true;
-  } else if (testFilter !== 'only') {
+  } else if (testFilter !== 'only' && !stagingOnly) {
     // Geral/B2B excluem conversas em atendimento humano (Luma assumiu) — essas
     // so aparecem na aba "Luma". Sem isso, conversa atendida apareceria em duas
-    // abas. Nao vale pra aba Testes, que mostra a persona em qualquer estado.
+    // abas. Nao vale pras abas Testes/Testers, que sao recortes de populacao
+    // (quem e' a pessoa), nao de estado — mostram o contato atendido ou nao.
     scope.is_being_attended = { [Op.not]: true };
   }
 
@@ -219,9 +229,20 @@ const buildContactScopeWhere = ({
     });
   }
 
-  const stagingEnvCondition = buildStagingEnvironmentCondition(Op, environment);
-  if (stagingEnvCondition) {
-    conditions.push(stagingEnvCondition);
+  if (stagingOnly) {
+    // A aba Testers E' a whitelist. Aplicar buildStagingEnvironmentCondition
+    // aqui a esvaziaria em prod (o filtro exclui exatamente esse universo) e
+    // seria redundante em homolog (que ja mostra so o universo QA). Combinado
+    // com testFilter='exclude' do caller, sobram os humanos reais: whitelist
+    // MENOS as personas sinteticas (range 5500000000XXX / path test-persona|).
+    conditions.push({
+      id: { [Op.in]: Sequelize.literal(STAGING_CONTACT_IDS_SUBQUERY) },
+    });
+  } else {
+    const stagingEnvCondition = buildStagingEnvironmentCondition(Op, environment);
+    if (stagingEnvCondition) {
+      conditions.push(stagingEnvCondition);
+    }
   }
 
   return { scope, conditions };
@@ -246,6 +267,7 @@ const getAllContactsWithMessages = async ({
   filters = {},
   testFilter = 'exclude',
   b2bFilter = 'exclude',
+  stagingFilter = 'none',
   environment = 'prod',
 }) => {
   try {
@@ -261,6 +283,7 @@ const getAllContactsWithMessages = async ({
       role,
       testFilter,
       b2bFilter,
+      stagingFilter,
       environment,
     });
 
@@ -1971,6 +1994,22 @@ const getB2bContactsCount = async ({ role, environment = 'prod' }) => {
   }
 };
 
+// Badge da aba Testers: conta o MESMO conjunto que getAllTesterContacts lista.
+const getTesterContactsCount = async ({ role, environment = 'prod' }) => {
+  try {
+    return await countContactsInScope({
+      role,
+      testFilter: 'exclude',
+      b2bFilter: 'none',
+      stagingFilter: 'only',
+      environment,
+    });
+  } catch (error) {
+    console.error('❌ ERRO getTesterContactsCount:', error.message);
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 // Resumo de dias com mensagens pra um contato — alimenta o date picker da
 // mensageria. Agrupa por dia em America/Sao_Paulo (timezone do operador) e
 // aplica o mesmo filtro de role usado em getContactByPetOwnerId/getContactByContactId.
@@ -2046,6 +2085,7 @@ export default {
   getOrdersByContactId,
   getTestContactsCount,
   getB2bContactsCount,
+  getTesterContactsCount,
   getInAttendanceContactsCount,
   getMessagesDaysSummary,
 };

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -47,6 +47,23 @@ router.get(
   ChatController.getB2bContactsCount,
 );
 
+// Aba Testers: humanos reais na whitelist staging_users (sócios testando em
+// prod com o próprio número). São excluídos das outras abas pelo filtro de
+// environment — até então só o Debug Mode os alcançava.
+router.get(
+  '/messages/getAllTesterContacts',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getAllTesterContacts,
+);
+
+router.get(
+  '/messages/getTesterContactsCount',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getTesterContactsCount,
+);
+
 // Badge da aba "Luma" no painel — conta contacts.is_being_attended=true.
 router.get(
   '/messages/getInAttendanceContactsCount',

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -221,7 +221,7 @@ const getTesterContactsCount = async ({ role, environment = 'prod' }) => {
 const getInAttendanceContactsCount = async ({
   role,
   testFilter = 'exclude',
-  b2bFilter = 'exclude',
+  b2bFilter = 'none',
   environment = 'prod',
 } = {}) => {
   try {
@@ -237,6 +237,8 @@ const getInAttendanceContactsCount = async ({
   }
 };
 
+// Aba Luma: recorte de ESTADO (em atendimento humano), nao de populacao —
+// por isso b2bFilter='none' (clinicas incluidas). Ver repository.
 const getAllContactsBeingAttended = async ({
   role,
   page = 1,
@@ -244,7 +246,7 @@ const getAllContactsBeingAttended = async ({
   user_id,
   filters = {},
   testFilter = 'exclude',
-  b2bFilter = 'exclude',
+  b2bFilter = 'none',
   environment = 'prod',
 }) => {
   try {

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -89,10 +89,17 @@ const getAllContactsWithMessages = async ({
   filters = {},
   testFilter = 'exclude',
   b2bFilter = 'exclude',
+  stagingFilter = 'none',
   environment = 'prod',
 }) => {
   try {
-    const filtersForEnv = resolveTestB2bFiltersForEnvironment(environment, testFilter, b2bFilter);
+    // A aba Testers ja define seu universo explicitamente (whitelist menos
+    // personas sinteticas) e nao pode ser reescrita pelo ajuste de homolog —
+    // senao em homolog o 'exclude' viraria 'none' e as personas voltariam.
+    const filtersForEnv =
+      stagingFilter === 'only'
+        ? { testFilter, b2bFilter }
+        : resolveTestB2bFiltersForEnvironment(environment, testFilter, b2bFilter);
     const result = await ChatRepository.getAllContactsWithMessages({
       role,
       page,
@@ -101,6 +108,7 @@ const getAllContactsWithMessages = async ({
       filters,
       testFilter: filtersForEnv.testFilter,
       b2bFilter: filtersForEnv.b2bFilter,
+      stagingFilter,
       environment,
     });
     const contacts = result.contacts;
@@ -159,6 +167,30 @@ const getAllB2bContacts = async ({
   });
 };
 
+// Aba Testers: humanos reais na whitelist staging_users (socios testando em
+// prod com o proprio numero). testFilter='exclude' tira as personas sinteticas
+// que tambem vivem na whitelist — sobra so gente de verdade.
+const getAllTesterContacts = async ({
+  role,
+  page = 1,
+  limit = 15,
+  user_id,
+  filters = {},
+  environment = 'prod',
+}) => {
+  return getAllContactsWithMessages({
+    role,
+    page,
+    limit,
+    user_id,
+    filters,
+    testFilter: 'exclude',
+    b2bFilter: 'none',
+    stagingFilter: 'only',
+    environment,
+  });
+};
+
 const getTestContactsCount = async ({ role, environment = 'prod' }) => {
   try {
     return await ChatRepository.getTestContactsCount({ role, environment });
@@ -170,6 +202,14 @@ const getTestContactsCount = async ({ role, environment = 'prod' }) => {
 const getB2bContactsCount = async ({ role, environment = 'prod' }) => {
   try {
     return await ChatRepository.getB2bContactsCount({ role, environment });
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
+const getTesterContactsCount = async ({ role, environment = 'prod' }) => {
+  try {
+    return await ChatRepository.getTesterContactsCount({ role, environment });
   } catch (error) {
     throw new Error(`Service error: ${error.message}`);
   }
@@ -473,8 +513,10 @@ export default {
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getAllB2bContacts,
+  getAllTesterContacts,
   getTestContactsCount,
   getB2bContactsCount,
+  getTesterContactsCount,
   getInAttendanceContactsCount,
   markAsAnswered,
   getMessagesDaysSummary,


### PR DESCRIPTION
> ⚠️ **Empilhado sobre #78** (base: `fix/mensageria-badge-parity`). Mergear aquele primeiro.

Tres conversas que existiam mas o operador nao conseguia alcancar pelo painel.

## 1. Aba Testers (`feat`)

Quem esta na whitelist `staging_users` (hoje os socios testando em prod com o proprio numero) e' excluido de Geral, Luma, B2B **e da busca** pelo filtro de environment. Na pratica o chat deles so era alcancavel pelo **Debug Mode** — o operador nao tinha como saber que a conversa existia.

Adiciona `GET /messages/getAllTesterContacts` + `/getTesterContactsCount`, via `stagingFilter='only'` no builder de escopo. A aba mostra a whitelist **MENOS** as personas sinteticas (o range `5500000000XXX` tambem vive em `staging_users`), entao sobram os humanos reais. Por ser um recorte deliberado do universo QA, e' a unica aba que nao aplica o filtro de environment — que e' justamente quem esconde essas conversas.

## 2. Busca acha a whitelist (`fix`)

Buscar "matheus" devolvia *"Nenhuma conversa encontrada"* com a conversa existindo. Aba e busca tem intencoes diferentes: a aba e' listagem passiva (o operador nao pediu por ninguem), a busca e' o oposto — ele digitou um nome especifico. Em prod a busca agora exclui so as personas **sinteticas**; a whitelist volta a ser encontravel.

## 3. Clinica em atendimento sumia de todas as abas (`fix`)

A B2B exclui quem esta em atendimento e a Luma excluia clinicas. No instante em que um operador assumia o atendimento de uma clinica, a conversa **nao aparecia em aba nenhuma**. A Luma e' um recorte de ESTADO, nao de populacao — passa a incluir clinicas.

## Verificacao (banco de producao)

```
GET /getTesterContactsCount -> 200 {"data":{"count":2}}
GET /getAllTesterContacts   -> 200 Matheus Araujo, Lucas Bergman
GET /getB2bContactsCount    -> 200 {"data":{"count":0}}

busca "matheus"    -> Matheus Araujo (5531999300962)
busca "5500000000" -> (vazio: personas sinteticas seguem fora)
Luma: predicado que excluia clinicas sumiu da query (com controle positivo)
```

Geral/B2B inalteradas em prod e homolog. Nenhuma persona sintetica vazou pra aba Testers.

⚠️ Nenhuma clinica em prod tem `chat_history` hoje, entao o caso #3 nao pode ser observado com dado real — foi verificado pelo SQL gerado.

**Requer o PR do frontend** (`Latta-app/frontend` → `feat/mensageria-aba-testers`). Mergear o backend antes; se inverter, o count falha silencioso e a aba so nao aparece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)