### PR TITLE
fix(ci): health check do deploy corria contra o boot e marcava falha em deploy que deu certo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,28 @@ jobs:
             git pull origin main
             npm install --production=false
             pm2 restart all 2>/dev/null || (pkill -f 'node.*app.js' || true; nohup npm start > /tmp/backend.log 2>&1 &)
-            sleep 3
-            echo "Deploy concluido — verificando saude..."
-            curl -sf http://localhost:8000/ > /dev/null && echo "OK API respondendo" || (tail -30 /tmp/backend.log; exit 1)
+
+            # Health check com retry. Antes era um curl unico apos `sleep 3`, que
+            # corria contra o boot do app: o pm2 reinicia em ~0s mas o Express so
+            # escuta na 8000 alguns segundos depois (conecta no banco, sincroniza
+            # models). O curl dava connection refused e o deploy era marcado como
+            # falha mesmo tendo funcionado — 4 runs seguidos em julho/2026. Pior:
+            # o fallback dumpava /tmp/backend.log, que so existe quando o pm2
+            # falha, entao o erro real ficava invisivel ("cannot open ... log").
+            echo "Deploy concluido — aguardando a API subir..."
+            for i in $(seq 1 20); do
+              if curl -sf http://localhost:8000/ > /dev/null; then
+                echo "OK API respondendo (${i}a tentativa, ~$((i * 2))s)"
+                exit 0
+              fi
+              sleep 2
+            done
+
+            echo "API nao respondeu em 40s. Diagnostico:"
+            pm2 list || true
+            pm2 logs --lines 40 --nostream || true
+            [ -f /tmp/backend.log ] && tail -30 /tmp/backend.log
+            exit 1
 
       - name: Smoke test
         run: |


### PR DESCRIPTION
## O deploy nunca esteve quebrado — o semaforo e' que estava

Os 4 ultimos runs do **Deploy to EC2** apareceram vermelhos, mas o deploy tinha **funcionado**. Prova, do log do run do #80:

```
Updating 4e2bb9f..0f70d7a          <- git pull trouxe o commit
[PM2] [latta_platform](0) ✓        <- app reiniciou, status online
Deploy concluido — verificando saude...
tail: cannot open '/tmp/backend.log' for reading: No such file or directory
Process exited with status 1        <- unica coisa que falhou
```

E as rotas novas respondem em producao (401 = existe e exige token; rota inventada = 404), confirmando que o codigo subiu.

## Causa raiz

O health check era um `curl` **unico** apos `sleep 3`. O pm2 reinicia em ~0s, mas o Express so passa a escutar na 8000 alguns segundos depois (conecta no banco, sincroniza models). O curl pegava *connection refused* → `exit 1`. Por ser uma corrida, as vezes passava — o que explica os sucessos intermitentes no historico.

Pior: o fallback do `||` dumpava `/tmp/backend.log`, arquivo que **so existe no caminho em que o pm2 FALHA** (`nohup npm start > /tmp/backend.log`). Como o pm2 tinha funcionado, o log nao existia, e o unico erro visivel virava `tail: cannot open` — que nao diz nada sobre o deploy.

## Fix

- Retry: 20 tentativas x 2s (40s) em vez de um curl unico apos 3s.
- No caminho de falha, dumpa `pm2 list` + `pm2 logs` — onde o erro real estaria.

## Por que importa alem do ruido

Com o semaforo vermelho por padrao, **o dia em que o deploy quebrar de verdade ninguem vai notar a diferenca**. Foi exatamente o que aconteceu comigo: olhei o historico, vi "ultimo sucesso em 02/07" e conclui que tinha 2 semanas de commits sem deploy. Nao tinha.

## Verificacao

YAML e sintaxe do shell validados (`yaml.safe_load` + `bash -n`). **O merge deste PR e' o proprio teste**: ele dispara o workflow — se ficar verde, o health check passou a esperar o boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)