### PR TITLE
feat(metricas): endpoint de métricas do cliente + proxy client_ranking (issues 04/05/06)

### DIFF
--- a/src/api/controllers/chat-history.controller.js
+++ b/src/api/controllers/chat-history.controller.js
@@ -311,6 +311,46 @@ const getOrdersByContactId = async (req, res) => {
   }
 };
 
+// Retrato de valor do cliente (visão Métricas do painel direito da
+// mensageria). Contato sem pet_owner → 200 com shape vazio (found=false);
+// gate de homolog negado → 404 (não vaza existência do contact).
+const getClientMetricsByContactId = async (req, res) => {
+  try {
+    const { contact_id } = req.params;
+    const { environment } = req.user;
+
+    if (!contact_id) {
+      return res.status(400).json({
+        code: 'MISSING_CONTACT_ID',
+        message: 'contact_id is required',
+      });
+    }
+
+    const result = await ChatService.getClientMetricsByContactId({
+      contact_id,
+      environment: environment || 'prod',
+    });
+
+    if (result === null) {
+      return res.status(404).json({
+        code: 'CONTACT_NOT_FOUND',
+        message: 'Contact not found',
+      });
+    }
+
+    return res.status(200).json({
+      code: 'CLIENT_METRICS_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Error retrieving client metrics by contact id:', error);
+    return res.status(500).json({
+      code: 'CLIENT_METRICS_RETRIEVAL_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 const getContactByPetOwnerIdOrPhone = async (req, res) => {
   try {
     const { pet_owner_id, contact } = req.query;
@@ -633,6 +673,7 @@ export default {
   getContactByPetOwnerId,
   getContactByContactId,
   getOrdersByContactId,
+  getClientMetricsByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getAllB2bContacts,

--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -261,6 +261,31 @@ const getTimeToEvent = async (req, res) => {
   }
 };
 
+// Ranking global de clientes e itens (seção do cockpit — issue 06 de
+// docs/issues/mensageria-metricas-e-moods/ no monorepo).
+const getClientRanking = async (req, res) => {
+  try {
+    const rawLimit = req.query.limit != null ? parseInt(req.query.limit, 10) : undefined;
+    const result = await DashboardService.getClientRanking({
+      window: req.query.window,
+      limit: Number.isInteger(rawLimit) ? rawLimit : undefined,
+      includeTest: parseIncludeTest(req.query),
+      refresh: parseRefresh(req.query),
+    });
+
+    return res.status(200).json({
+      code: 'DASHBOARD_CLIENT_RANKING_RETRIEVED',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Erro ao buscar dashboard client ranking:', error);
+    return res.status(500).json({
+      code: 'DASHBOARD_CLIENT_RANKING_ERROR',
+      message: error.message,
+    });
+  }
+};
+
 export default {
   getDashboardSummary,
   getAbandonedFlows,
@@ -272,4 +297,5 @@ export default {
   getCohortRetention,
   getTimeToEvent,
   searchPhone,
+  getClientRanking,
 };

--- a/src/api/repositories/chat-history.repository.js
+++ b/src/api/repositories/chat-history.repository.js
@@ -1963,6 +1963,47 @@ const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10 }) => {
   }
 };
 
+// Retrato de valor do cliente (visão Métricas do painel direito) — issues
+// 04/05 de docs/issues/mensageria-metricas-e-moods/ (monorepo). Resolve
+// contact_id → pet_owner_id (mesmo padrão de getOrdersByContactId) e delega
+// a agregação pra RPC get_client_metrics (SECURITY DEFINER, predicados
+// canônicos do cockpit: _is_latta_revenue, status pago, test personas).
+// Raw query porque o model Sequelize Order não conhece orders.source.
+const getClientMetricsByContactId = async ({ contact_id }) => {
+  try {
+    const contact = await Contact.findOne({
+      where: { id: contact_id },
+      attributes: ['id', 'pet_owner_id'],
+    });
+
+    if (!contact?.pet_owner_id) {
+      // Contato sem pet_owner → resposta vazia válida (mesma shape da RPC).
+      return {
+        pet_owner_id: null,
+        found: false,
+        latta: { total_spent: 0, paid_orders: 0, avg_ticket: null, last_order_at: null },
+        petz_legacy: { orders_count: 0, total_spent: 0, oldest_at: null, newest_at: null },
+        top_items: [],
+        gmv_filter: 'latta_only',
+        generated_at: new Date().toISOString(),
+      };
+    }
+
+    const sequelize = ChatHistory.sequelize;
+    const rows = await sequelize.query(
+      `SELECT get_client_metrics(CAST(:pet_owner_id AS uuid)) AS metrics`,
+      {
+        replacements: { pet_owner_id: contact.pet_owner_id },
+        type: Sequelize.QueryTypes.SELECT,
+      },
+    );
+    return rows[0]?.metrics ?? null;
+  } catch (error) {
+    console.error('❌ ERRO getClientMetricsByContactId:', error.message);
+    throw new Error(`Repository error: ${error.message}`);
+  }
+};
+
 
 // Badge da aba Luma: conta o MESMO conjunto que getAllContactsBeingAttended
 // lista (em atendimento humano, com chat_history, fora do universo QA em prod,
@@ -2106,6 +2147,7 @@ export default {
   getContactByContactId,
   getContactByPetOwnerIdOrPhone,
   getOrdersByContactId,
+  getClientMetricsByContactId,
   getTestContactsCount,
   getB2bContactsCount,
   getTesterContactsCount,

--- a/src/api/routes/private/chat-history.routes.js
+++ b/src/api/routes/private/chat-history.routes.js
@@ -100,6 +100,16 @@ router.get(
   ChatController.getOrdersByContactId,
 );
 
+// Retrato de valor do cliente (visão Métricas do painel direito) — RPC
+// get_client_metrics no Supabase. Issues 04/05 de
+// docs/issues/mensageria-metricas-e-moods/ (monorepo).
+router.get(
+  '/messages/metrics/by-contact/:contact_id',
+  verifyToken,
+  checkRole(['admin', 'superAdmin', 'attendant']),
+  ChatController.getClientMetricsByContactId,
+);
+
 router.get(
   '/messages/getContactByPetOwnerIdOrPhone',
   verifyToken,

--- a/src/api/routes/private/dashboard.routes.js
+++ b/src/api/routes/private/dashboard.routes.js
@@ -75,4 +75,13 @@ router.get(
   DashboardController.getContactDrilldown,
 );
 
+// Ranking global de clientes e itens (seção do cockpit — issue 06 de
+// docs/issues/mensageria-metricas-e-moods/ no monorepo).
+router.get(
+  '/client-ranking',
+  verifyToken,
+  checkRole(ALLOWED),
+  DashboardController.getClientRanking,
+);
+
 export default router;

--- a/src/api/services/chat-history.service.js
+++ b/src/api/services/chat-history.service.js
@@ -425,6 +425,26 @@ const getOrdersByContactId = async ({ contact_id, page = 1, limit = 10, environm
   }
 };
 
+// Retrato de valor do cliente (visão Métricas). Mesmo gate de homolog do
+// getOrdersByContactId: operador em environment=homolog só vê contacts da
+// whitelist staging_users — fora dela, null (controller responde 404).
+const getClientMetricsByContactId = async ({ contact_id, environment = 'prod' }) => {
+  try {
+    if (environment === 'homolog') {
+      const contact = await Contact.findOne({
+        where: { id: contact_id },
+        attributes: ['id', 'cellphone'],
+      });
+      if (!(await canAccessContactInEnvironment(contact, environment))) {
+        return null;
+      }
+    }
+    return await ChatRepository.getClientMetricsByContactId({ contact_id });
+  } catch (error) {
+    throw new Error(`Service error: ${error.message}`);
+  }
+};
+
 const getContactByPetOwnerIdOrPhone = async ({
   pet_owner_id,
   contact,
@@ -512,6 +532,7 @@ export default {
   getContactByPetOwnerId,
   getContactByContactId,
   getOrdersByContactId,
+  getClientMetricsByContactId,
   getContactByPetOwnerIdOrPhone,
   getAllTestContacts,
   getAllB2bContacts,

--- a/src/api/services/dashboard.service.js
+++ b/src/api/services/dashboard.service.js
@@ -15,7 +15,12 @@ const ALLOWED_ACTIONS = new Set([
   'cohort_retention',
   'time_to_event',
   'search',
+  'client_ranking',
 ]);
+
+// Janelas próprias do ranking de clientes/itens (issue 06 de
+// docs/issues/mensageria-metricas-e-moods/ no monorepo) — inclui lifetime.
+const ALLOWED_RANKING_WINDOWS = new Set(['30d', '90d', 'lifetime']);
 
 const ALLOWED_TIME_TO_EVENT = new Set(['first_purchase', 'first_pro', 'first_utilization']);
 const ALLOWED_FUNNEL_STEPS = new Set([
@@ -45,6 +50,7 @@ const buildUrl = ({
   isPro,
   lookbackDays,
   event,
+  limit,
   includeTest,
   refresh,
 }) => {
@@ -59,6 +65,7 @@ const buildUrl = ({
   else if (isPro === false) params.set('is_pro', 'false');
   if (lookbackDays != null) params.set('lookback_days', String(lookbackDays));
   if (event) params.set('event', event);
+  if (limit != null) params.set('limit', String(limit));
   if (includeTest === true) params.set('include_test', 'true');
   if (refresh) params.set('refresh', '1');
   const query = params.toString();
@@ -75,6 +82,7 @@ const callDashboardMetrics = async ({
   isPro,
   lookbackDays,
   event,
+  limit,
   includeTest,
   refresh = false,
 } = {}) => {
@@ -84,7 +92,16 @@ const callDashboardMetrics = async ({
   if (!ALLOWED_ACTIONS.has(action)) {
     throw new Error(`action inválida: ${action}`);
   }
-  if (window && !ALLOWED_WINDOWS.has(window)) {
+  // client_ranking tem janelas próprias (30d/90d/lifetime); as demais actions
+  // seguem as janelas padrão do dashboard.
+  if (action === 'client_ranking') {
+    if (window && !ALLOWED_RANKING_WINDOWS.has(window)) {
+      throw new Error(`window inválida para client_ranking: ${window}`);
+    }
+    if (limit != null && (!Number.isInteger(limit) || limit < 1 || limit > 50)) {
+      throw new Error('limit deve ser inteiro entre 1 e 50');
+    }
+  } else if (window && !ALLOWED_WINDOWS.has(window)) {
     throw new Error(`window inválida: ${window}`);
   }
   if (action === 'drilldown' && !phone) {
@@ -117,7 +134,7 @@ const callDashboardMetrics = async ({
     throw new Error(`event inválido: ${event}`);
   }
 
-  const url = buildUrl({ action, window, phone, step, scope, q, isPro, lookbackDays, event, includeTest, refresh });
+  const url = buildUrl({ action, window, phone, step, scope, q, isPro, lookbackDays, event, limit, includeTest, refresh });
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -164,6 +181,10 @@ const getTimeToEvent = async ({ window, event, includeTest, refresh } = {}) =>
 const searchPhone = async ({ q } = {}) =>
   callDashboardMetrics({ action: 'search', q });
 
+// Ranking global de clientes e itens (seção do cockpit — issue 06).
+const getClientRanking = async ({ window, limit, includeTest, refresh } = {}) =>
+  callDashboardMetrics({ action: 'client_ranking', window, limit, includeTest, refresh });
+
 export default {
   getDashboardSummary,
   getAbandonedFlows,
@@ -175,4 +196,5 @@ export default {
   getCohortRetention,
   getTimeToEvent,
   searchPhone,
+  getClientRanking,
 };


### PR DESCRIPTION
Frente A das métricas de clientes na mensageria — camada Express. Spec no monorepo: `docs/issues/mensageria-metricas-e-moods/` (issues 04/05/06). PR irmão do monorepo: Matheus3FY/Latta#828 (RPCs + action da EF — **precisa das migrations aplicadas e da EF deployada antes deste ir pra prod**).

## O que muda (1 commit por frente)

- **Issues 04/05** (`e8fa5e2`): `GET /chat-history/messages/metrics/by-contact/:contact_id` — endpoint irmão do de pedidos paginados, mesma auth JWT + roles (`admin`/`superAdmin`/`attendant`) e mesmo gate de homolog (whitelist `staging_users`). Resolve `contact_id → pet_owner_id` (padrão de `getOrdersByContactId`) e chama a RPC `get_client_metrics` via raw query (`sequelize.query` + replacements — o model `Order` não conhece `orders.source`). Retrato + top 5 itens num payload só. Contato sem `pet_owner` → 200 com shape vazio (`found=false`); gate homolog negado → 404.
- **Issue 06** (`cc5dfd7`): `GET /admin/dashboard/client-ranking` — proxy pra action `client_ranking` da EF `dashboard-metrics` (cache Redis 60s herdado). `window=30d|90d|lifetime` (validação separada das janelas padrão), `limit=1..50`, `include_test`, `refresh`.

## Como validar

1. Depois das migrations + deploy da EF (PR do monorepo): deploy no EC2 (com o pré-check de disco de sempre).
2. `GET /api/chat-history/messages/metrics/by-contact/<contact_id>` com token de admin → `CLIENT_METRICS_RETRIEVED` com `latta`/`petz_legacy`/`top_items`; conferir contra o drilldown do cockpit pro mesmo contato.
3. Sem token → 401; role sem permissão → 403; contato sem pet_owner → 200 `found=false`.
4. `GET /api/admin/dashboard/client-ranking?window=30d` → `DASHBOARD_CLIENT_RANKING_RETRIEVED`; segunda chamada com `cache: "hit"` no payload da EF.

Verificado localmente: `node --check` OK nos 7 arquivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
